### PR TITLE
General cleanup

### DIFF
--- a/changes/tests.py
+++ b/changes/tests.py
@@ -107,7 +107,7 @@ class AuthenticatedAPITestCase(APITestCase):
             "mother_id": "846877e6-afaa-43de-acb1-09f61ad4de99",
             "action": "change_language",
             "data": {"test_normaluser_change": "test_normaluser_changed"},
-            "source": self.make_source_adminuser()
+            "source": self.make_source_normaluser()
         }
         return Change.objects.create(**data)
 
@@ -835,7 +835,7 @@ class TestChangeUnsubscribeHousehold(AuthenticatedAPITestCase):
             "action": "unsubscribe_household_only",
             "data": {
                 "household_id": "629eaf3c-04e5-4404-8a27-3ab3b811326a",
-                "loss_reason": "miscarriage"
+                "reason": "miscarriage"
             },
             "source": self.make_source_adminuser()
         }
@@ -889,7 +889,7 @@ class TestChangeUnsubscribeMother(AuthenticatedAPITestCase):
             "mother_id": "846877e6-afaa-43de-acb1-09f61ad4de99",
             "action": "unsubscribe_mother_only",
             "data": {
-                "loss_reason": "miscarriage"
+                "reason": "miscarriage"
             },
             "source": self.make_source_adminuser()
         }
@@ -941,7 +941,7 @@ class TestChangeLoss(AuthenticatedAPITestCase):
         change_data = {
             "mother_id": "846877e6-afaa-43de-acb1-09f61ad4de99",
             "action": "change_loss",
-            "data": {"loss_reason": "miscarriage"},
+            "data": {"reason": "miscarriage"},
             "source": self.make_source_adminuser()
         }
         change = Change.objects.create(**change_data)
@@ -1046,7 +1046,7 @@ class TestChangeLoss(AuthenticatedAPITestCase):
         change_data = {
             "mother_id": "846877e6-afaa-43de-acb1-09f61ad4de99",
             "action": "change_loss",
-            "data": {"loss_reason": "miscarriage"},
+            "data": {"reason": "miscarriage"},
             "source": self.make_source_adminuser()
         }
         change = Change.objects.create(**change_data)

--- a/changes/views.py
+++ b/changes/views.py
@@ -1,21 +1,7 @@
 from .models import Source, Change
-from rest_hooks.models import Hook
-from rest_framework import viewsets, mixins, generics
+from rest_framework import mixins, generics
 from rest_framework.permissions import IsAuthenticated
 from .serializers import ChangeSerializer
-from registrations.serializers import HookSerializer
-
-
-class HookViewSet(viewsets.ModelViewSet):
-    """
-    Retrieve, create, update or destroy webhooks.
-    """
-    permission_classes = (IsAuthenticated,)
-    queryset = Hook.objects.all()
-    serializer_class = HookSerializer
-
-    def perform_create(self, serializer):
-        serializer.save(user=self.request.user)
 
 
 class ChangePost(mixins.CreateModelMixin, generics.GenericAPIView):

--- a/hellomama_registration/utils.py
+++ b/hellomama_registration/utils.py
@@ -66,7 +66,6 @@ def get_schedule(schedule_id):
 def get_subscriptions(identity):
     """ Gets the first active subscription found for an identity
     """
-    print(identity)
     url = settings.STAGE_BASED_MESSAGING_URL + 'subscriptions/'
     params = {'id': identity, 'active': True}
     headers = {'Authorization': [


### PR DESCRIPTION
- [x] Change `loss_reason` in tests to `reason` (not all optout/unsubscribe reasons are for loss)
- [x] Remove `print` statement
- [x] Remove `HookViewset` in Changes app - already in Registrations app
