### PR TITLE
Upgrade webhooks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         'redis==2.10.5',
         'pytz==2015.7',
         'six==1.10.0',
-        'django-rest-hooks==1.2.1',
+        'django-rest-hooks==1.3.1',
         'go-http==0.3.0'
     ],
     classifiers=[


### PR DESCRIPTION
https://pypi.python.org/pypi/django-rest-hooks/1.2.2

Now properly supports `+` based, all record creators, hook sends
