### PR TITLE
Test run speedup

### DIFF
--- a/hellomama_registration/testsettings.py
+++ b/hellomama_registration/testsettings.py
@@ -15,3 +15,5 @@ CELERY_RESULT_BACKEND = 'djcelery.backends.database:DatabaseBackend'
 
 METRICS_URL = "http://metrics-url"
 METRICS_AUTH_TOKEN = "REPLACEME"
+
+PASSWORD_HASHERS = ('django.contrib.auth.hashers.MD5PasswordHasher',)


### PR DESCRIPTION
Currently the tests use the default password hasher, taking ~30s to run on my machine.

Changing to the MD5 password hasher for tests reduces this to ~4s on my machine.
