### PR TITLE
Add registration by receiver type metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,6 @@ cache backend for them.
 
 ##### registrations.receiver_type.{{type}}.sum
 `sum` Number of registrations per receiver type
+
+##### registrations.receiver_type.{{type}}.last
+`last` Total number of registrations per receiver type

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ cache backend for them.
 
 ##### registrations.msg_type.{{type}}.last
 `last` Total number of registrations per message type
-`sum` Number of registrations per message type
 
 ##### registrations.receiver_type.{{type}}.sum
 `sum` Number of registrations per receiver type

--- a/README.md
+++ b/README.md
@@ -17,4 +17,7 @@ HelloMama Registration accepts registrations for the Hello Mama project.
 `sum` Total number of unique health workers who have completed registrations
 
 ##### registrations.msg_type.{{type}}.sum
-`sum` Total number of registrations per message type
+`sum` Number of registrations per message type
+
+##### registrations.receiver_type.{{type}}.sum
+`sum` Number of registrations per receiver type

--- a/changes/tests.py
+++ b/changes/tests.py
@@ -14,7 +14,8 @@ from rest_hooks.models import model_saved
 from hellomama_registration import utils
 from registrations.models import (
     Source, Registration, SubscriptionRequest, registration_post_save,
-    fire_created_metric, fire_unique_operator_metric, fire_message_type_metric)
+    fire_created_metric, fire_unique_operator_metric, fire_message_type_metric,
+    fire_receiver_type_metric)
 from .models import Change, change_post_save
 from .tasks import implement_action
 
@@ -72,6 +73,8 @@ class AuthenticatedAPITestCase(APITestCase):
         post_save.disconnect(receiver=fire_unique_operator_metric,
                              sender=Registration)
         post_save.disconnect(receiver=fire_message_type_metric,
+                             sender=Registration)
+        post_save.disconnect(receiver=fire_receiver_type_metric,
                              sender=Registration)
         post_save.disconnect(receiver=model_saved,
                              dispatch_uid='instance-saved-hook')

--- a/hellomama_registration/settings.py
+++ b/hellomama_registration/settings.py
@@ -207,6 +207,8 @@ METRICS_REALTIME.extend(
     ['registrations.msg_type.%s.last' % mt for mt in MSG_TYPES])
 METRICS_REALTIME.extend(
     ['registrations.receiver_type.%s.sum' % rt for rt in RECEIVER_TYPES])
+METRICS_REALTIME.extend(
+    ['registrations.receiver_type.%s.last' % rt for rt in RECEIVER_TYPES])
 METRICS_SCHEDULED = [
 ]
 METRICS_SCHEDULED_TASKS = [

--- a/hellomama_registration/settings.py
+++ b/hellomama_registration/settings.py
@@ -193,6 +193,9 @@ CELERY_ROUTES = {
 }
 
 MSG_TYPES = ["text", "audio"]
+RECEIVER_TYPES = [
+    "mother_father", "mother_only", "father_only", "mother_family",
+    "mother_friend", "friend_only", "family_only"]
 
 METRICS_REALTIME = [
     'registrations.created.sum',
@@ -200,6 +203,8 @@ METRICS_REALTIME = [
 ]
 METRICS_REALTIME.extend(
     ['registrations.msg_type.%s.sum' % mt for mt in MSG_TYPES])
+METRICS_REALTIME.extend(
+    ['registrations.receiver_type.%s.sum' % rt for rt in RECEIVER_TYPES])
 METRICS_SCHEDULED = [
 ]
 METRICS_SCHEDULED_TASKS = [

--- a/registrations/models.py
+++ b/registrations/models.py
@@ -118,6 +118,21 @@ def fire_unique_operator_metric(sender, instance, created, **kwargs):
         })
 
 
+def get_or_incr_cache(key, func):
+    """
+    Used to either get a value from the cache, or if the value doesn't exist
+    in the cache, run the function to get a value to use to populate the cache
+    """
+    value = cache.get(key)
+    if value is None:
+        value = func()
+        cache.set(key, value)
+    else:
+        cache.incr(key)
+        value += 1
+    return value
+
+
 @receiver(post_save, sender=Registration)
 def fire_message_type_metric(sender, instance, created, **kwargs):
     """
@@ -136,14 +151,9 @@ def fire_message_type_metric(sender, instance, created, **kwargs):
         })
 
         total_key = 'registrations.msg_type.%s.last' % msg_type
-        total = cache.get(total_key)
-        if total is None:
-            total = Registration.objects.filter(
-                data__msg_type=msg_type).count()
-            cache.set(total_key, total)
-        else:
-            cache.incr(total_key)
-            total += 1
+        total = get_or_incr_cache(
+            total_key,
+            Registration.objects.filter(data__msg_type=msg_type).count)
         fire_metric.apply_async(kwargs={
             'metric_name': total_key,
             'metric_value': total,
@@ -156,10 +166,19 @@ def fire_receiver_type_metric(sender, instance, created, **kwargs):
     from .tasks import fire_metric, is_valid_msg_receiver
     if (created and instance.data and instance.data['msg_receiver'] and
             is_valid_msg_receiver(instance.data['msg_receiver'])):
+        msg_receiver = instance.data['msg_receiver']
         fire_metric.apply_async(kwargs={
-            "metric_name": 'registrations.receiver_type.%s.sum' % (
-                instance.data['msg_receiver']),
+            "metric_name": 'registrations.receiver_type.%s.sum' % msg_receiver,
             "metric_value": 1.0,
+        })
+
+        total_key = 'registrations.receiver_type.%s.last' % msg_receiver
+        total = get_or_incr_cache(
+            total_key,
+            Registration.objects.filter(data__msg_receiver=msg_receiver).count)
+        fire_metric.apply_async(kwargs={
+            'metric_name': total_key,
+            'metric_value': total,
         })
 
 

--- a/registrations/models.py
+++ b/registrations/models.py
@@ -119,6 +119,19 @@ def fire_message_type_metric(sender, instance, created, **kwargs):
         })
 
 
+@receiver(post_save, sender=Registration)
+def fire_receiver_type_metric(sender, instance, created, **kwargs):
+    """Fires a metric for each receiver message type of each subscription."""
+    from .tasks import fire_metric, is_valid_msg_receiver
+    if (created and instance.data and instance.data['msg_receiver'] and
+            is_valid_msg_receiver(instance.data['msg_receiver'])):
+        fire_metric.apply_async(kwargs={
+            "metric_name": 'registrations.receiver_type.%s.sum' % (
+                instance.data['msg_receiver']),
+            "metric_value": 1.0,
+        })
+
+
 @python_2_unicode_compatible
 class SubscriptionRequest(models.Model):
     """ A data model that maps to the Stagebased Store

--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -36,9 +36,7 @@ def is_valid_msg_type(msg_type):
 
 
 def is_valid_msg_receiver(msg_receiver):
-    return msg_receiver in ["mother_father", "mother_only", "father_only",
-                            "mother_family", "mother_friend", "friend_only",
-                            "family_only"]
+    return msg_receiver in settings.RECEIVER_TYPES
 
 
 def is_valid_loss_reason(loss_reason):

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -1795,6 +1795,13 @@ class TestMetricsAPI(AuthenticatedAPITestCase):
                 'registrations.receiver_type.mother_friend.sum',
                 'registrations.receiver_type.friend_only.sum',
                 'registrations.receiver_type.family_only.sum',
+                'registrations.receiver_type.mother_father.last',
+                'registrations.receiver_type.mother_only.last',
+                'registrations.receiver_type.father_only.last',
+                'registrations.receiver_type.mother_family.last',
+                'registrations.receiver_type.mother_friend.last',
+                'registrations.receiver_type.friend_only.last',
+                'registrations.receiver_type.family_only.last',
                 'registrations.source.testnormaluser.sum',
                 'registrations.source.testadminuser.sum',
             ]

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -1979,7 +1979,6 @@ class TestMetrics(AuthenticatedAPITestCase):
         # remove post_save hooks to prevent teardown errors
         post_save.disconnect(fire_unique_operator_metric, sender=Registration)
 
-    @responses.activate
     def test_message_type_metric(self):
         """
         When creating a registration, a metric should be fired for the message
@@ -1996,6 +1995,23 @@ class TestMetrics(AuthenticatedAPITestCase):
         )
 
         post_save.disconnect(fire_message_type_metric, sender=Registration)
+
+    def test_receiver_type_metric(self):
+        """
+        When creating a registration, a metric should be fired for the receiver
+        type that the registration is created for.
+        """
+        adapter = self._mount_session()
+        post_save.connect(fire_receiver_type_metric, sender=Registration)
+
+        self.make_registration_adminuser()
+
+        self._check_request(
+            adapter.request, 'POST',
+            data={"registrations.receiver_type.mother_only.sum": 1.0}
+        )
+
+        post_save.disconnect(fire_receiver_type_metric, sender=Registration)
 
 
 class TestSubscriptionRequestWebhook(AuthenticatedAPITestCase):

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -1769,6 +1769,13 @@ class TestMetricsAPI(AuthenticatedAPITestCase):
                 'registrations.unique_operators.sum',
                 'registrations.msg_type.text.sum',
                 'registrations.msg_type.audio.sum',
+                'registrations.receiver_type.mother_father.sum',
+                'registrations.receiver_type.mother_only.sum',
+                'registrations.receiver_type.father_only.sum',
+                'registrations.receiver_type.mother_family.sum',
+                'registrations.receiver_type.mother_friend.sum',
+                'registrations.receiver_type.friend_only.sum',
+                'registrations.receiver_type.family_only.sum',
             ]
         )
 

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -23,7 +23,8 @@ from hellomama_registration import utils
 from registrations import tasks
 from .models import (
     Source, Registration, SubscriptionRequest, registration_post_save,
-    fire_created_metric, fire_unique_operator_metric, fire_message_type_metric)
+    fire_created_metric, fire_unique_operator_metric, fire_message_type_metric,
+    fire_receiver_type_metric)
 from .tasks import (
     validate_registration,
     is_valid_date, is_valid_uuid, is_valid_lang, is_valid_msg_type,
@@ -177,6 +178,8 @@ class AuthenticatedAPITestCase(APITestCase):
         post_save.disconnect(receiver=fire_unique_operator_metric,
                              sender=Registration)
         post_save.disconnect(receiver=fire_message_type_metric,
+                             sender=Registration)
+        post_save.disconnect(receiver=fire_receiver_type_metric,
                              sender=Registration)
         post_save.disconnect(receiver=model_saved,
                              dispatch_uid='instance-saved-hook')


### PR DESCRIPTION
This is to add a metric firing whenever a new registration is created, namespaced by the receiver type of the registration.
