### PR TITLE
Add message type last metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # hellomama-registration
 HelloMama Registration accepts registrations for the Hello Mama project.
 
+This app uses the Django cache framework for efficient calculation of metrics,
+so if you are running multiple instances, make sure to setup a shared Django
+cache backend for them.
+
 ## Apps & Models:
   * registrations
     * Source

--- a/README.md
+++ b/README.md
@@ -17,4 +17,7 @@ HelloMama Registration accepts registrations for the Hello Mama project.
 `sum` Total number of unique health workers who have completed registrations
 
 ##### registrations.msg_type.{{type}}.sum
-`sum` Total number of registrations per message type
+`sum` Number of registrations per message type
+
+##### registrations.msg_type.{{type}}.last
+`last` Total number of registrations per message type

--- a/hellomama_registration/settings.py
+++ b/hellomama_registration/settings.py
@@ -200,6 +200,8 @@ METRICS_REALTIME = [
 ]
 METRICS_REALTIME.extend(
     ['registrations.msg_type.%s.sum' % mt for mt in MSG_TYPES])
+METRICS_REALTIME.extend(
+    ['registrations.msg_type.%s.last' % mt for mt in MSG_TYPES])
 METRICS_SCHEDULED = [
 ]
 METRICS_SCHEDULED_TASKS = [

--- a/registrations/models.py
+++ b/registrations/models.py
@@ -2,6 +2,7 @@ import uuid
 
 from django.contrib.postgres.fields import JSONField
 from django.contrib.auth.models import User
+from django.core.cache import cache
 from django.db import models
 from django.db.models.signals import post_save
 from django.dispatch import receiver
@@ -108,14 +109,33 @@ def fire_unique_operator_metric(sender, instance, created, **kwargs):
 
 @receiver(post_save, sender=Registration)
 def fire_message_type_metric(sender, instance, created, **kwargs):
-    """Fires a metric for each message type of each subscription."""
+    """
+    Fires a metric for each message type of each registration.
+
+    Fires both a `sum` metric with 1.0 for each registration, as well as a
+    `last` metric with the total amount of registrations for that type.
+    """
     from .tasks import fire_metric, is_valid_msg_type
-    if (created and instance.data and instance.data['msg_type'] and
+    if (created and instance.data and instance.data.get('msg_type') and
             is_valid_msg_type(instance.data['msg_type'])):
+        msg_type = instance.data['msg_type']
         fire_metric.apply_async(kwargs={
-            "metric_name": 'registrations.msg_type.%s.sum' % (
-                instance.data['msg_type']),
+            "metric_name": 'registrations.msg_type.%s.sum' % msg_type,
             "metric_value": 1.0,
+        })
+
+        total_key = 'registrations.msg_type.%s.last' % msg_type
+        total = cache.get(total_key)
+        if total is None:
+            total = Registration.objects.filter(
+                data__msg_type=msg_type).count()
+            cache.set(total_key, total)
+        else:
+            cache.incr(total_key)
+            total += 1
+        fire_metric.apply_async(kwargs={
+            'metric_name': total_key,
+            'metric_value': total,
         })
 
 

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -38,10 +38,12 @@ class RecordingAdapter(TestAdapter):
 
     """ Record the request that was handled by the adapter.
     """
-    request = None
+    def __init__(self, *args, **kwargs):
+        self.requests = []
+        super(RecordingAdapter, self).__init__(*args, **kwargs)
 
     def send(self, request, *args, **kw):
-        self.request = request
+        self.requests.append(request)
         return super(RecordingAdapter, self).send(request, *args, **kw)
 
 
@@ -1902,8 +1904,9 @@ class TestMetrics(AuthenticatedAPITestCase):
             "session": self.session
         })
         # Check
+        [request] = adapter.requests
         self._check_request(
-            adapter.request, 'POST',
+            request, 'POST',
             data={"foo.last": 1.0}
         )
         self.assertEqual(result.get(),
@@ -1919,8 +1922,9 @@ class TestMetrics(AuthenticatedAPITestCase):
         self.make_registration_adminuser()
 
         # Check
+        [request] = adapter.requests
         self._check_request(
-            adapter.request, 'POST',
+            request, 'POST',
             data={"registrations.created.sum": 1.0}
         )
         # remove post_save hooks to prevent teardown errors
@@ -1936,8 +1940,9 @@ class TestMetrics(AuthenticatedAPITestCase):
         self.make_registration_adminuser()
 
         # Check
+        [request] = adapter.requests
         self._check_request(
-            adapter.request, 'POST',
+            request, 'POST',
             data={"registrations.unique_operators.sum": 1.0}
         )
 

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -1769,6 +1769,8 @@ class TestMetricsAPI(AuthenticatedAPITestCase):
                 'registrations.unique_operators.sum',
                 'registrations.msg_type.text.sum',
                 'registrations.msg_type.audio.sum',
+                'registrations.msg_type.text.last',
+                'registrations.msg_type.audio.last',
             ]
         )
 

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -12,6 +12,7 @@ from django.contrib.auth.models import User
 from django.test import TestCase
 from django.db.models.signals import post_save
 from django.conf import settings
+from django.core.cache import cache
 from rest_framework import status
 from rest_framework.test import APIClient
 from rest_framework.authtoken.models import Token
@@ -1984,17 +1985,58 @@ class TestMetrics(AuthenticatedAPITestCase):
     @responses.activate
     def test_message_type_metric(self):
         """
-        When creating a registration, a metric should be fired for the message
-        type that the registration is created for.
+        When creating a registration, two metrics should be fired for the
+        message type that the registration is created for, one of type sum, and
+        one of type last.
         """
         adapter = self._mount_session()
         post_save.connect(fire_message_type_metric, sender=Registration)
 
         self.make_registration_adminuser()
 
+        [request_sum, request_last] = adapter.requests
         self._check_request(
-            adapter.request, 'POST',
+            request_sum, 'POST',
             data={"registrations.msg_type.text.sum": 1.0}
+        )
+        self._check_request(
+            request_last, 'POST',
+            data={"registrations.msg_type.text.last": 1.0}
+        )
+
+        post_save.disconnect(fire_message_type_metric, sender=Registration)
+
+    @responses.activate
+    def test_message_type_metric_multiple(self):
+        """
+        When creating a registration, two metrics should be fired for the
+        message type that the registration is created for, one of type sum, and
+        one of type last. The sum metric should always be one, the last metric
+        should increment for each registration of that type.
+        """
+        adapter = self._mount_session()
+        post_save.connect(fire_message_type_metric, sender=Registration)
+
+        cache.clear()
+        self.make_registration_adminuser()
+        self.make_registration_adminuser()
+
+        [r_sum1, r_last1, r_sum2, r_last2] = adapter.requests
+        self._check_request(
+            r_sum1, 'POST',
+            data={"registrations.msg_type.text.sum": 1.0}
+        )
+        self._check_request(
+            r_last1, 'POST',
+            data={"registrations.msg_type.text.last": 1.0}
+        )
+        self._check_request(
+            r_sum2, 'POST',
+            data={"registrations.msg_type.text.sum": 1.0}
+        )
+        self._check_request(
+            r_last2, 'POST',
+            data={"registrations.msg_type.text.last": 2.0}
         )
 
         post_save.disconnect(fire_message_type_metric, sender=Registration)


### PR DESCRIPTION
We have the msg_type.{{type}}.sum metric, which gives us the sum of registrations per message type.

This PR adds the msg_type.{{type}}.last metric, which gives us the total amount of registrations per message type.
