### PR TITLE
Add cache backend setting to not timeout

### DIFF
--- a/hellomama_registration/settings.py
+++ b/hellomama_registration/settings.py
@@ -192,6 +192,13 @@ CELERY_ROUTES = {
     },
 }
 
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'TIMEOUT': None,
+    },
+}
+
 MSG_TYPES = ["text", "audio"]
 
 METRICS_REALTIME = [


### PR DESCRIPTION
So it turns out that by default, django sets its cache to expire every 5 minutes. This would not be very good for our metrics caching, so we should set it to not expire.
