### PR TITLE
Add metrics for metric repopulation

### DIFF
--- a/hellomama_registration/utils.py
+++ b/hellomama_registration/utils.py
@@ -69,7 +69,13 @@ def search_identities(params):
         'Content-Type': 'application/json'
     }
     r = requests.get(url, params=params, headers=headers).json()
-    return r["results"]
+    while True:
+        for identity in r['results']:
+            yield identity
+        if r.get('next'):
+            r = requests.get(r['next'], headers=headers).json()
+        else:
+            break
 
 
 def patch_identity(identity, data):

--- a/registrations/admin.py
+++ b/registrations/admin.py
@@ -15,7 +15,7 @@ class RepopulateMetricsForm(forms.Form):
         label='AMQP URL', initial='amqp://guest:guest@localhost:5672/%2F',
         widget=forms.TextInput(attrs={'size': 80}))
     prefix = forms.CharField(
-        label='Metric Name Prefix', initial='',
+        label='Metric Name Prefix', initial='', required=False,
         widget=forms.TextInput(attrs={'size': 80}))
     metric_names = forms.MultipleChoiceField(choices=[])
     graphite_retentions = forms.CharField(

--- a/registrations/metrics.py
+++ b/registrations/metrics.py
@@ -33,6 +33,11 @@ class MetricGenerator(object):
                 partial(
                     self.registrations_receiver_type_total_last, receiver_type)
             )
+        for language in settings.LANGUAGES:
+            setattr(
+                self, 'registrations_language_{}_sum'.format(language),
+                partial(self.registrations_language_sum, language)
+            )
 
     def generate_metric(self, name, start, end):
         """
@@ -93,10 +98,18 @@ class MetricGenerator(object):
             .filter(data__msg_receiver=receiver_type)\
             .count()
 
-    def registrations_receiver_type_total_last(self, msg_type, start, end):
+    def registrations_receiver_type_total_last(
+            self, receiver_type, start, end):
         return Registration.objects\
             .filter(created_at__lte=end)\
-            .filter(data__msg_receiver=msg_type)\
+            .filter(data__msg_receiver=receiver_type)\
+            .count()
+
+    def registrations_language_sum(self, language, start, end):
+        return Registration.objects\
+            .filter(created_at__gt=start)\
+            .filter(created_at__lte=end)\
+            .filter(data__language=language)\
             .count()
 
 

--- a/registrations/metrics.py
+++ b/registrations/metrics.py
@@ -2,6 +2,8 @@ import pika
 
 from hellomama_registration import utils
 
+from .models import Registration
+
 
 class MetricGenerator(object):
     def generate_metric(self, name, start, end):
@@ -15,6 +17,12 @@ class MetricGenerator(object):
         """
         metric_func = getattr(self, name.replace('.', '_'))
         return metric_func(start, end)
+
+    def registrations_created_sum(self, start, end):
+        return Registration.objects\
+            .filter(created_at__gt=start)\
+            .filter(created_at__lte=end)\
+            .count()
 
 
 def send_metric(amqp_url, prefix, name, value, timestamp):

--- a/registrations/metrics.py
+++ b/registrations/metrics.py
@@ -38,6 +38,10 @@ class MetricGenerator(object):
                 self, 'registrations_language_{}_sum'.format(language),
                 partial(self.registrations_language_sum, language)
             )
+            setattr(
+                self, 'registrations_language_{}_total_last'.format(language),
+                partial(self.registrations_language_total_last, language)
+            )
 
     def generate_metric(self, name, start, end):
         """
@@ -108,6 +112,12 @@ class MetricGenerator(object):
     def registrations_language_sum(self, language, start, end):
         return Registration.objects\
             .filter(created_at__gt=start)\
+            .filter(created_at__lte=end)\
+            .filter(data__language=language)\
+            .count()
+
+    def registrations_language_total_last(self, language, start, end):
+        return Registration.objects\
             .filter(created_at__lte=end)\
             .filter(data__language=language)\
             .count()

--- a/registrations/metrics.py
+++ b/registrations/metrics.py
@@ -7,7 +7,7 @@ from functools import partial
 
 from hellomama_registration import utils
 
-from .models import Registration
+from .models import Registration, registrations_for_identity_field
 
 
 class MetricGenerator(object):
@@ -128,23 +128,11 @@ class MetricGenerator(object):
             .count()
 
     def registrations_state_sum(self, state, start, end):
-        registrations = Registration.objects\
+        return registrations_for_identity_field(
+            {"details__state": state})\
             .filter(created_at__gt=start)\
-            .filter(created_at__lte=end)
-
-        state_cache = {}
-        registration_count = 0
-
-        for reg in registrations:
-            reg_state = state_cache.get(reg.data['operator_id'])
-            if reg_state is None:
-                reg_state = utils.get_identity(reg.data['operator_id']).get(
-                    'details', {}).get('state')
-                state_cache[reg.data['operator_id']] = reg_state
-            if reg_state == state:
-                registration_count += 1
-
-        return registration_count
+            .filter(created_at__lte=end)\
+            .count()
 
 
 def send_metric(amqp_url, prefix, name, value, timestamp):

--- a/registrations/metrics.py
+++ b/registrations/metrics.py
@@ -24,6 +24,11 @@ class MetricGenerator(object):
             .filter(created_at__lte=end)\
             .count()
 
+    def registrations_created_total_last(self, start, end):
+        return Registration.objects\
+            .filter(created_at__lte=end)\
+            .count()
+
 
 def send_metric(amqp_url, prefix, name, value, timestamp):
     parameters = pika.URLParameters(amqp_url)

--- a/registrations/metrics.py
+++ b/registrations/metrics.py
@@ -47,6 +47,10 @@ class MetricGenerator(object):
                 self, 'registrations_state_{}_sum'.format(state),
                 partial(self.registrations_state_sum, state)
             )
+            setattr(
+                self, 'registrations_state_{}_total_last'.format(state),
+                partial(self.registrations_state_total_last, state)
+            )
 
     def generate_metric(self, name, start, end):
         """
@@ -131,6 +135,12 @@ class MetricGenerator(object):
         return registrations_for_identity_field(
             {"details__state": state})\
             .filter(created_at__gt=start)\
+            .filter(created_at__lte=end)\
+            .count()
+
+    def registrations_state_total_last(self, state, start, end):
+        return registrations_for_identity_field(
+            {"details__state": state})\
             .filter(created_at__lte=end)\
             .count()
 

--- a/registrations/metrics.py
+++ b/registrations/metrics.py
@@ -27,6 +27,12 @@ class MetricGenerator(object):
                     receiver_type),
                 partial(self.registrations_receiver_type_sum, receiver_type)
             )
+            setattr(
+                self, 'registrations_receiver_type_{}_total_last'.format(
+                    receiver_type),
+                partial(
+                    self.registrations_receiver_type_total_last, receiver_type)
+            )
 
     def generate_metric(self, name, start, end):
         """
@@ -85,6 +91,12 @@ class MetricGenerator(object):
             .filter(created_at__gt=start)\
             .filter(created_at__lte=end)\
             .filter(data__msg_receiver=receiver_type)\
+            .count()
+
+    def registrations_receiver_type_total_last(self, msg_type, start, end):
+        return Registration.objects\
+            .filter(created_at__lte=end)\
+            .filter(data__msg_receiver=msg_type)\
             .count()
 
 

--- a/registrations/metrics.py
+++ b/registrations/metrics.py
@@ -51,6 +51,11 @@ class MetricGenerator(object):
                 self, 'registrations_state_{}_total_last'.format(state),
                 partial(self.registrations_state_total_last, state)
             )
+        for role in settings.ROLES:
+            setattr(
+                self, 'registrations_role_{}_sum'.format(role),
+                partial(self.registrations_role_sum, role)
+            )
 
     def generate_metric(self, name, start, end):
         """
@@ -141,6 +146,13 @@ class MetricGenerator(object):
     def registrations_state_total_last(self, state, start, end):
         return registrations_for_identity_field(
             {"details__state": state})\
+            .filter(created_at__lte=end)\
+            .count()
+
+    def registrations_role_sum(self, role, start, end):
+        return registrations_for_identity_field(
+            {"details__role": role})\
+            .filter(created_at__gt=start)\
             .filter(created_at__lte=end)\
             .count()
 

--- a/registrations/metrics.py
+++ b/registrations/metrics.py
@@ -21,6 +21,12 @@ class MetricGenerator(object):
                 self, 'registrations_msg_type_{}_total_last'.format(msg_type),
                 partial(self.registrations_msg_type_total_last, msg_type)
             )
+        for receiver_type in settings.RECEIVER_TYPES:
+            setattr(
+                self, 'registrations_receiver_type_{}_sum'.format(
+                    receiver_type),
+                partial(self.registrations_receiver_type_sum, receiver_type)
+            )
 
     def generate_metric(self, name, start, end):
         """
@@ -72,6 +78,13 @@ class MetricGenerator(object):
         return Registration.objects\
             .filter(created_at__lte=end)\
             .filter(data__msg_type=msg_type)\
+            .count()
+
+    def registrations_receiver_type_sum(self, receiver_type, start, end):
+        return Registration.objects\
+            .filter(created_at__gt=start)\
+            .filter(created_at__lte=end)\
+            .filter(data__msg_receiver=receiver_type)\
             .count()
 
 

--- a/registrations/metrics.py
+++ b/registrations/metrics.py
@@ -17,6 +17,10 @@ class MetricGenerator(object):
                 self, 'registrations_msg_type_{}_sum'.format(msg_type),
                 partial(self.registrations_msg_type_sum, msg_type)
             )
+            setattr(
+                self, 'registrations_msg_type_{}_total_last'.format(msg_type),
+                partial(self.registrations_msg_type_total_last, msg_type)
+            )
 
     def generate_metric(self, name, start, end):
         """
@@ -60,6 +64,12 @@ class MetricGenerator(object):
     def registrations_msg_type_sum(self, msg_type, start, end):
         return Registration.objects\
             .filter(created_at__gt=start)\
+            .filter(created_at__lte=end)\
+            .filter(data__msg_type=msg_type)\
+            .count()
+
+    def registrations_msg_type_total_last(self, msg_type, start, end):
+        return Registration.objects\
             .filter(created_at__lte=end)\
             .filter(data__msg_type=msg_type)\
             .count()

--- a/registrations/metrics.py
+++ b/registrations/metrics.py
@@ -56,6 +56,10 @@ class MetricGenerator(object):
                 self, 'registrations_role_{}_sum'.format(role),
                 partial(self.registrations_role_sum, role)
             )
+            setattr(
+                self, 'registrations_role_{}_total_last'.format(role),
+                partial(self.registrations_role_total_last, role)
+            )
 
     def generate_metric(self, name, start, end):
         """
@@ -153,6 +157,12 @@ class MetricGenerator(object):
         return registrations_for_identity_field(
             {"details__role": role})\
             .filter(created_at__gt=start)\
+            .filter(created_at__lte=end)\
+            .count()
+
+    def registrations_role_total_last(self, role, start, end):
+        return registrations_for_identity_field(
+            {"details__role": role})\
             .filter(created_at__lte=end)\
             .count()
 

--- a/registrations/models.py
+++ b/registrations/models.py
@@ -263,9 +263,7 @@ def fire_language_metric(sender, instance, created, **kwargs):
 def registrations_for_identity_field(params):
     from hellomama_registration.utils import search_identities
     identities = search_identities(params=params)
-    ids = ()
-    for data in identities:
-        ids = ids + (data["id"],)
+    ids = tuple(data['id'] for data in identities)
 
     return Registration.objects.filter(
         data__operator_id__in=ids)

--- a/registrations/test_metrics.py
+++ b/registrations/test_metrics.py
@@ -4,12 +4,15 @@ except ImportError:
     from unittest import mock
 
 from datetime import datetime
+from django.contrib.auth.models import User
 from django.test import TestCase
 
 from .metrics import MetricGenerator, send_metric
+from .tests import AuthenticatedAPITestCase
+from .models import Registration, Source
 
 
-class MetricsGeneratorTests(TestCase):
+class MetricsGeneratorTests(AuthenticatedAPITestCase):
     def test_generate_metric(self):
         """
         The generate_metric function should call the correct function with the
@@ -22,6 +25,35 @@ class MetricsGeneratorTests(TestCase):
         generator.generate_metric('foo.bar', start, end)
 
         generator.foo_bar.assert_called_once_with(start, end)
+
+    def create_registration_on(self, timestamp, source):
+        r = Registration.objects.create(mother_id='motherid', source=source)
+        r.created_at = timestamp
+        r.save()
+        return r
+
+    def test_registrations_created_sum(self):
+        """
+        Should return the amount of registrations in the given timeframe.
+
+        Only one of the borders of the timeframe should be included, to avoid
+        duplication.
+        """
+        user = User.objects.create(username='user1')
+        source = Source.objects.create(
+            name='TestSource', authority='hw_full', user=user)
+
+        start = datetime(2016, 10, 15)
+        end = datetime(2016, 10, 25)
+
+        self.create_registration_on(datetime(2016, 10, 14), source)  # Before
+        self.create_registration_on(datetime(2016, 10, 15), source)  # On
+        self.create_registration_on(datetime(2016, 10, 20), source)  # In
+        self.create_registration_on(datetime(2016, 10, 25), source)  # On
+        self.create_registration_on(datetime(2016, 10, 26), source)  # After
+
+        reg_count = MetricGenerator().registrations_created_sum(start, end)
+        self.assertEqual(reg_count, 2)
 
 
 class SendMetricTests(TestCase):

--- a/registrations/test_metrics.py
+++ b/registrations/test_metrics.py
@@ -229,6 +229,44 @@ class MetricsGeneratorTests(AuthenticatedAPITestCase):
                 MetricGenerator(),
                 'registrations_receiver_type_{}_sum'.format(receiver_type))))
 
+    def test_registrations_receiver_type_total_last(self):
+        """
+        Should return the amount of registrations before the end of the
+        timeframe for the given receiver type.
+        """
+        user = User.objects.create(username='user1')
+        source = Source.objects.create(
+            name='TestSource', authority='hw_full', user=user)
+
+        start = datetime(2016, 10, 15)
+        end = datetime(2016, 10, 25)
+
+        self.create_registration_on(
+            datetime(2016, 10, 14), source, msg_receiver='type1')  # Before
+        self.create_registration_on(
+            datetime(2016, 10, 20), source, msg_receiver='type1')  # During
+        self.create_registration_on(
+            datetime(2016, 10, 20), source, msg_receiver='type2')  # Wrong type
+        self.create_registration_on(
+            datetime(2016, 10, 25), source, msg_receiver='type1')  # On
+        self.create_registration_on(
+            datetime(2016, 10, 26), source, msg_receiver='type1')  # After
+
+        reg_count = MetricGenerator().registrations_receiver_type_total_last(
+            'type1', start, end)
+        self.assertEqual(reg_count, 3)
+
+    def test_registrations_receiver_type_total_last_correct_functions(self):
+        """
+        The correct functions must be created on the MetricGenerator according
+        to the settings in the settings file.
+        """
+        for receiver_type in settings.RECEIVER_TYPES:
+            self.assertTrue(callable(getattr(
+                MetricGenerator(),
+                'registrations_receiver_type_{}_total_last'.format(
+                    receiver_type))))
+
 
 class SendMetricTests(TestCase):
     @mock.patch('pika.BlockingConnection')

--- a/registrations/test_metrics.py
+++ b/registrations/test_metrics.py
@@ -461,12 +461,6 @@ class MetricsGeneratorTests(AuthenticatedAPITestCase):
         source2 = Source.objects.create(
             name='TestSource2', authority='hw_full', user=user2)
 
-        url = 'http://localhost:8001/api/v1/identities/search/?' \
-              'details__state=state1'
-        responses.add_callback(
-            responses.GET, url, callback=self.identity_search_callback,
-            content_type="application/json", match_querystring=True)
-
         start = datetime(2016, 10, 15)
         end = datetime(2016, 10, 25)
 

--- a/registrations/test_metrics.py
+++ b/registrations/test_metrics.py
@@ -350,19 +350,15 @@ class MetricsGeneratorTests(AuthenticatedAPITestCase):
                 'registrations_language_{}_total_last'.format(
                     language))))
 
-    def identity1_callback(self, request):
+    def identity_search_callback(self, request):
         headers = {'Content-Type': "application/json"}
         resp = {
-            "id": "id1",
-            "details": {"state": "state1"},
-        }
-        return (200, headers, json.dumps(resp))
-
-    def identity2_callback(self, request):
-        headers = {'Content-Type': "application/json"}
-        resp = {
-            "id": "id2",
-            "details": {"state": "state2"},
+            "results": [
+                {
+                    "id": "id1",
+                    "details": {"state": "state2"},
+                },
+            ]
         }
         return (200, headers, json.dumps(resp))
 
@@ -370,7 +366,7 @@ class MetricsGeneratorTests(AuthenticatedAPITestCase):
     def test_registrations_state_sum(self):
         """
         Should return the amount of registrations in the given timeframe for
-        a specific state. The identity store calls should be cached.
+        a specific state.
 
         Only one of the borders of the timeframe should be included, to avoid
         duplication.
@@ -379,14 +375,11 @@ class MetricsGeneratorTests(AuthenticatedAPITestCase):
         source = Source.objects.create(
             name='TestSource', authority='hw_full', user=user)
 
-        url = 'http://localhost:8001/api/v1/identities/id1/'
+        url = 'http://localhost:8001/api/v1/identities/search/?' \
+              'details__state=state1'
         responses.add_callback(
-            responses.GET, url, callback=self.identity1_callback,
-            content_type="application/json")
-        url = 'http://localhost:8001/api/v1/identities/id2/'
-        responses.add_callback(
-            responses.GET, url, callback=self.identity2_callback,
-            content_type="application/json")
+            responses.GET, url, callback=self.identity_search_callback,
+            content_type="application/json", match_querystring=True)
 
         start = datetime(2016, 10, 15)
         end = datetime(2016, 10, 25)

--- a/registrations/test_metrics.py
+++ b/registrations/test_metrics.py
@@ -26,11 +26,10 @@ class MetricsGeneratorTests(AuthenticatedAPITestCase):
 
         generator.foo_bar.assert_called_once_with(start, end)
 
-    def create_registration_on(self, timestamp, source, operator_id=None):
-        r = Registration.objects.create(mother_id='motherid', source=source)
+    def create_registration_on(self, timestamp, source, **kwargs):
+        r = Registration.objects.create(
+            mother_id='motherid', source=source, data=kwargs)
         r.created_at = timestamp
-        if operator_id:
-            r.data = {'operator_id': operator_id}
         r.save()
         return r
 
@@ -89,14 +88,20 @@ class MetricsGeneratorTests(AuthenticatedAPITestCase):
         end = datetime(2016, 10, 25)
 
         # Registration before should exclude 1
-        self.create_registration_on(datetime(2016, 10, 14), source, '1')
-        self.create_registration_on(datetime(2016, 10, 20), source, '1')
+        self.create_registration_on(
+            datetime(2016, 10, 14), source, operator_id='1')
+        self.create_registration_on(
+            datetime(2016, 10, 20), source, operator_id='1')
         # Two registrations during should exclude 2
-        self.create_registration_on(datetime(2016, 10, 20), source, '2')
-        self.create_registration_on(datetime(2016, 10, 20), source, '2')
+        self.create_registration_on(
+            datetime(2016, 10, 20), source, operator_id='2')
+        self.create_registration_on(
+            datetime(2016, 10, 20), source, operator_id='2')
         # Registration after shouldn't exclude 3
-        self.create_registration_on(datetime(2016, 10, 20), source, '3')
-        self.create_registration_on(datetime(2016, 10, 26), source, '3')
+        self.create_registration_on(
+            datetime(2016, 10, 20), source, operator_id='3')
+        self.create_registration_on(
+            datetime(2016, 10, 26), source, operator_id='3')
 
         reg_count = MetricGenerator().registrations_unique_operators_sum(
             start, end)

--- a/registrations/test_metrics.py
+++ b/registrations/test_metrics.py
@@ -267,6 +267,48 @@ class MetricsGeneratorTests(AuthenticatedAPITestCase):
                 'registrations_receiver_type_{}_total_last'.format(
                     receiver_type))))
 
+    def test_registrations_language_sum(self):
+        """
+        Should return the amount of registrations in the given timeframe for
+        a specific receiver
+
+        Only one of the borders of the timeframe should be included, to avoid
+        duplication.
+        """
+        user = User.objects.create(username='user1')
+        source = Source.objects.create(
+            name='TestSource', authority='hw_full', user=user)
+
+        start = datetime(2016, 10, 15)
+        end = datetime(2016, 10, 25)
+
+        self.create_registration_on(
+            datetime(2016, 10, 14), source, language='eng')  # Before
+        self.create_registration_on(
+            datetime(2016, 10, 15), source, language='eng')  # On
+        self.create_registration_on(
+            datetime(2016, 10, 20), source, language='eng')  # During
+        self.create_registration_on(
+            datetime(2016, 10, 20), source, language='hau')  # Wrong type
+        self.create_registration_on(
+            datetime(2016, 10, 25), source, language='eng')  # On
+        self.create_registration_on(
+            datetime(2016, 10, 26), source, language='eng')  # After
+
+        reg_count = MetricGenerator().registrations_language_sum(
+            'eng', start, end)
+        self.assertEqual(reg_count, 2)
+
+    def test_registrations_language_sum_correct_functions(self):
+        """
+        The correct functions must be created on the MetricGenerator according
+        to the settings in the settings file.
+        """
+        for language in settings.LANGUAGES:
+            self.assertTrue(callable(getattr(
+                MetricGenerator(),
+                'registrations_language_{}_sum'.format(language))))
+
 
 class SendMetricTests(TestCase):
     @mock.patch('pika.BlockingConnection')

--- a/registrations/test_metrics.py
+++ b/registrations/test_metrics.py
@@ -55,6 +55,26 @@ class MetricsGeneratorTests(AuthenticatedAPITestCase):
         reg_count = MetricGenerator().registrations_created_sum(start, end)
         self.assertEqual(reg_count, 2)
 
+    def test_registrations_created_total_last(self):
+        """
+        Should return the total amount of registrations at the 'end' point in
+        time.
+        """
+        user = User.objects.create(username='user1')
+        source = Source.objects.create(
+            name='TestSource', authority='hw_full', user=user)
+
+        start = datetime(2016, 10, 15)
+        end = datetime(2016, 10, 25)
+
+        self.create_registration_on(datetime(2016, 10, 14), source)  # Before
+        self.create_registration_on(datetime(2016, 10, 25), source)  # On
+        self.create_registration_on(datetime(2016, 10, 26), source)  # After
+
+        reg_count = MetricGenerator().registrations_created_total_last(
+            start, end)
+        self.assertEqual(reg_count, 2)
+
 
 class SendMetricTests(TestCase):
     @mock.patch('pika.BlockingConnection')

--- a/registrations/test_metrics.py
+++ b/registrations/test_metrics.py
@@ -504,6 +504,50 @@ class MetricsGeneratorTests(AuthenticatedAPITestCase):
                 MetricGenerator(),
                 'registrations_role_{}_sum'.format(role))))
 
+    @responses.activate
+    def test_registrations_role_total_last(self):
+        """
+        Should return the amount of registrations up to the end of the
+        timeframe.
+        """
+        user = User.objects.create(username='user1')
+        source = Source.objects.create(
+            name='TestSource', authority='hw_full', user=user)
+
+        url = 'http://localhost:8001/api/v1/identities/search/?' \
+              'details__role=role1'
+        responses.add_callback(
+            responses.GET, url, callback=self.identity_search_callback,
+            content_type="application/json", match_querystring=True)
+
+        start = datetime(2016, 10, 15)
+        end = datetime(2016, 10, 25)
+
+        self.create_registration_on(
+            datetime(2016, 10, 14), source, operator_id='id1')  # Before
+        self.create_registration_on(
+            datetime(2016, 10, 20), source, operator_id='id1')  # During
+        self.create_registration_on(
+            datetime(2016, 10, 20), source, operator_id='id2')  # Wrong type
+        self.create_registration_on(
+            datetime(2016, 10, 25), source, operator_id='id1')  # On
+        self.create_registration_on(
+            datetime(2016, 10, 26), source, operator_id='id1')  # After
+
+        reg_count = MetricGenerator().registrations_role_total_last(
+            'role1', start, end)
+        self.assertEqual(reg_count, 3)
+
+    def test_registrations_role_total_last_correct_functions(self):
+        """
+        The correct functions must be created on the MetricGenerator according
+        to the settings in the settings file.
+        """
+        for role in settings.ROLES:
+            self.assertTrue(callable(getattr(
+                MetricGenerator(),
+                'registrations_role_{}_total_last'.format(role))))
+
 
 class SendMetricTests(TestCase):
     @mock.patch('pika.BlockingConnection')

--- a/registrations/test_metrics.py
+++ b/registrations/test_metrics.py
@@ -7,13 +7,13 @@ import json
 import responses
 
 from datetime import datetime
-from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase
 
 from .metrics import MetricGenerator, send_metric
 from .tests import AuthenticatedAPITestCase
 from .models import Registration, Source
+from hellomama_registration import utils
 
 
 class MetricsGeneratorTests(AuthenticatedAPITestCase):
@@ -143,16 +143,6 @@ class MetricsGeneratorTests(AuthenticatedAPITestCase):
             'type1', start, end)
         self.assertEqual(reg_count, 2)
 
-    def test_registrations_msg_type_sum_correct_functions(self):
-        """
-        The correct functions must be created on the MetricGenerator according
-        to the settings in the settings file.
-        """
-        for msg_type in settings.MSG_TYPES:
-            self.assertTrue(callable(getattr(
-                MetricGenerator(),
-                'registrations_msg_type_{}_sum'.format(msg_type))))
-
     def test_registrations_msg_type_total_last(self):
         """
         Should return the amount of registrations before the end of the
@@ -179,16 +169,6 @@ class MetricsGeneratorTests(AuthenticatedAPITestCase):
         reg_count = MetricGenerator().registrations_msg_type_total_last(
             'type1', start, end)
         self.assertEqual(reg_count, 3)
-
-    def test_registrations_msg_type_total_last_correct_functions(self):
-        """
-        The correct functions must be created on the MetricGenerator according
-        to the settings in the settings file.
-        """
-        for msg_type in settings.MSG_TYPES:
-            self.assertTrue(callable(getattr(
-                MetricGenerator(),
-                'registrations_msg_type_{}_total_last'.format(msg_type))))
 
     def test_registrations_receiver_type_sum(self):
         """
@@ -222,16 +202,6 @@ class MetricsGeneratorTests(AuthenticatedAPITestCase):
             'type1', start, end)
         self.assertEqual(reg_count, 2)
 
-    def test_registrations_receiver_type_sum_correct_functions(self):
-        """
-        The correct functions must be created on the MetricGenerator according
-        to the settings in the settings file.
-        """
-        for receiver_type in settings.RECEIVER_TYPES:
-            self.assertTrue(callable(getattr(
-                MetricGenerator(),
-                'registrations_receiver_type_{}_sum'.format(receiver_type))))
-
     def test_registrations_receiver_type_total_last(self):
         """
         Should return the amount of registrations before the end of the
@@ -258,17 +228,6 @@ class MetricsGeneratorTests(AuthenticatedAPITestCase):
         reg_count = MetricGenerator().registrations_receiver_type_total_last(
             'type1', start, end)
         self.assertEqual(reg_count, 3)
-
-    def test_registrations_receiver_type_total_last_correct_functions(self):
-        """
-        The correct functions must be created on the MetricGenerator according
-        to the settings in the settings file.
-        """
-        for receiver_type in settings.RECEIVER_TYPES:
-            self.assertTrue(callable(getattr(
-                MetricGenerator(),
-                'registrations_receiver_type_{}_total_last'.format(
-                    receiver_type))))
 
     def test_registrations_language_sum(self):
         """
@@ -302,16 +261,6 @@ class MetricsGeneratorTests(AuthenticatedAPITestCase):
             'eng', start, end)
         self.assertEqual(reg_count, 2)
 
-    def test_registrations_language_sum_correct_functions(self):
-        """
-        The correct functions must be created on the MetricGenerator according
-        to the settings in the settings file.
-        """
-        for language in settings.LANGUAGES:
-            self.assertTrue(callable(getattr(
-                MetricGenerator(),
-                'registrations_language_{}_sum'.format(language))))
-
     def test_registrations_language_total_last(self):
         """
         Should return the amount of registrations before the end of the
@@ -338,17 +287,6 @@ class MetricsGeneratorTests(AuthenticatedAPITestCase):
         reg_count = MetricGenerator().registrations_language_total_last(
             'eng', start, end)
         self.assertEqual(reg_count, 3)
-
-    def test_registrations_language_total_last_correct_functions(self):
-        """
-        The correct functions must be created on the MetricGenerator according
-        to the settings in the settings file.
-        """
-        for language in settings.LANGUAGES:
-            self.assertTrue(callable(getattr(
-                MetricGenerator(),
-                'registrations_language_{}_total_last'.format(
-                    language))))
 
     def identity_search_callback(self, request):
         headers = {'Content-Type': "application/json"}
@@ -401,16 +339,6 @@ class MetricsGeneratorTests(AuthenticatedAPITestCase):
             'state1', start, end)
         self.assertEqual(reg_count, 2)
 
-    def test_registrations_state_sum_correct_functions(self):
-        """
-        The correct functions must be created on the MetricGenerator according
-        to the settings in the settings file.
-        """
-        for state in settings.STATES:
-            self.assertTrue(callable(getattr(
-                MetricGenerator(),
-                'registrations_state_{}_sum'.format(state))))
-
     @responses.activate
     def test_registrations_state_total_last(self):
         """
@@ -444,16 +372,6 @@ class MetricsGeneratorTests(AuthenticatedAPITestCase):
         reg_count = MetricGenerator().registrations_state_total_last(
             'state1', start, end)
         self.assertEqual(reg_count, 3)
-
-    def test_registrations_state_total_last_correct_functions(self):
-        """
-        The correct functions must be created on the MetricGenerator according
-        to the settings in the settings file.
-        """
-        for state in settings.STATES:
-            self.assertTrue(callable(getattr(
-                MetricGenerator(),
-                'registrations_state_{}_total_last'.format(state))))
 
     @responses.activate
     def test_registrations_role_sum(self):
@@ -494,16 +412,6 @@ class MetricsGeneratorTests(AuthenticatedAPITestCase):
             'role1', start, end)
         self.assertEqual(reg_count, 2)
 
-    def test_registrations_role_sum_correct_functions(self):
-        """
-        The correct functions must be created on the MetricGenerator according
-        to the settings in the settings file.
-        """
-        for role in settings.ROLES:
-            self.assertTrue(callable(getattr(
-                MetricGenerator(),
-                'registrations_role_{}_sum'.format(role))))
-
     @responses.activate
     def test_registrations_role_total_last(self):
         """
@@ -538,15 +446,57 @@ class MetricsGeneratorTests(AuthenticatedAPITestCase):
             'role1', start, end)
         self.assertEqual(reg_count, 3)
 
-    def test_registrations_role_total_last_correct_functions(self):
+    def test_registrations_source_sum(self):
         """
-        The correct functions must be created on the MetricGenerator according
-        to the settings in the settings file.
+        Should return the amount of registrations in the given timeframe for
+        a specific source.
+
+        Only one of the borders of the timeframe should be included, to avoid
+        duplication.
         """
-        for role in settings.ROLES:
+        user1 = User.objects.create(username='user1')
+        user2 = User.objects.create(username='user2')
+        source1 = Source.objects.create(
+            name='TestSource1', authority='hw_full', user=user1)
+        source2 = Source.objects.create(
+            name='TestSource2', authority='hw_full', user=user2)
+
+        url = 'http://localhost:8001/api/v1/identities/search/?' \
+              'details__state=state1'
+        responses.add_callback(
+            responses.GET, url, callback=self.identity_search_callback,
+            content_type="application/json", match_querystring=True)
+
+        start = datetime(2016, 10, 15)
+        end = datetime(2016, 10, 25)
+
+        self.create_registration_on(
+            datetime(2016, 10, 14), source1)  # Before
+        self.create_registration_on(
+            datetime(2016, 10, 15), source1)  # On
+        self.create_registration_on(
+            datetime(2016, 10, 20), source1)  # During
+        self.create_registration_on(
+            datetime(2016, 10, 20), source2)  # Wrong type
+        self.create_registration_on(
+            datetime(2016, 10, 25), source1)  # On
+        self.create_registration_on(
+            datetime(2016, 10, 26), source1)  # After
+
+        reg_count = MetricGenerator().registrations_source_sum(
+            'user1', start, end)
+        self.assertEqual(reg_count, 2)
+
+    def test_that_all_metrics_are_present(self):
+        """
+        We need to make sure that we have a function for each of the metrics.
+        """
+        user = User.objects.create(username='user1')
+        Source.objects.create(
+            name='TestSource', authority='hw_full', user=user)
+        for metric in utils.get_available_metrics():
             self.assertTrue(callable(getattr(
-                MetricGenerator(),
-                'registrations_role_{}_total_last'.format(role))))
+                MetricGenerator(), metric.replace('.', '_'))))
 
 
 class SendMetricTests(TestCase):

--- a/registrations/test_metrics.py
+++ b/registrations/test_metrics.py
@@ -411,6 +411,50 @@ class MetricsGeneratorTests(AuthenticatedAPITestCase):
                 MetricGenerator(),
                 'registrations_state_{}_sum'.format(state))))
 
+    @responses.activate
+    def test_registrations_state_total_last(self):
+        """
+        Should return the amount of registrations until the end of the
+        timeframe.
+        """
+        user = User.objects.create(username='user1')
+        source = Source.objects.create(
+            name='TestSource', authority='hw_full', user=user)
+
+        url = 'http://localhost:8001/api/v1/identities/search/?' \
+              'details__state=state1'
+        responses.add_callback(
+            responses.GET, url, callback=self.identity_search_callback,
+            content_type="application/json", match_querystring=True)
+
+        start = datetime(2016, 10, 15)
+        end = datetime(2016, 10, 25)
+
+        self.create_registration_on(
+            datetime(2016, 10, 14), source, operator_id='id1')  # Before
+        self.create_registration_on(
+            datetime(2016, 10, 20), source, operator_id='id1')  # During
+        self.create_registration_on(
+            datetime(2016, 10, 20), source, operator_id='id2')  # Wrong type
+        self.create_registration_on(
+            datetime(2016, 10, 25), source, operator_id='id1')  # On
+        self.create_registration_on(
+            datetime(2016, 10, 26), source, operator_id='id1')  # After
+
+        reg_count = MetricGenerator().registrations_state_total_last(
+            'state1', start, end)
+        self.assertEqual(reg_count, 3)
+
+    def test_registrations_state_total_last_correct_functions(self):
+        """
+        The correct functions must be created on the MetricGenerator according
+        to the settings in the settings file.
+        """
+        for state in settings.STATES:
+            self.assertTrue(callable(getattr(
+                MetricGenerator(),
+                'registrations_state_{}_total_last'.format(state))))
+
 
 class SendMetricTests(TestCase):
     @mock.patch('pika.BlockingConnection')

--- a/registrations/test_metrics.py
+++ b/registrations/test_metrics.py
@@ -150,6 +150,43 @@ class MetricsGeneratorTests(AuthenticatedAPITestCase):
                 MetricGenerator(),
                 'registrations_msg_type_{}_sum'.format(msg_type))))
 
+    def test_registrations_msg_type_total_last(self):
+        """
+        Should return the amount of registrations before the end of the
+        timeframe for the given message type.
+        """
+        user = User.objects.create(username='user1')
+        source = Source.objects.create(
+            name='TestSource', authority='hw_full', user=user)
+
+        start = datetime(2016, 10, 15)
+        end = datetime(2016, 10, 25)
+
+        self.create_registration_on(
+            datetime(2016, 10, 14), source, msg_type='type1')  # Before
+        self.create_registration_on(
+            datetime(2016, 10, 20), source, msg_type='type1')  # During
+        self.create_registration_on(
+            datetime(2016, 10, 20), source, msg_type='type2')  # Wrong type
+        self.create_registration_on(
+            datetime(2016, 10, 25), source, msg_type='type1')  # On
+        self.create_registration_on(
+            datetime(2016, 10, 26), source, msg_type='type1')  # After
+
+        reg_count = MetricGenerator().registrations_msg_type_total_last(
+            'type1', start, end)
+        self.assertEqual(reg_count, 3)
+
+    def test_registrations_msg_type_total_last_correct_functions(self):
+        """
+        The correct functions must be created on the MetricGenerator according
+        to the settings in the settings file.
+        """
+        for msg_type in settings.MSG_TYPES:
+            self.assertTrue(callable(getattr(
+                MetricGenerator(),
+                'registrations_msg_type_{}_total_last'.format(msg_type))))
+
 
 class SendMetricTests(TestCase):
     @mock.patch('pika.BlockingConnection')


### PR DESCRIPTION
Since we added the framework for repopulating metrics here: https://github.com/praekelt/hellomama-registration/pull/100 , we now need to add the actual calculation of the individual metrics.
