### PR TITLE
Switch to one long task instead of lots of subtasks

### DIFF
--- a/hellomama_registration/settings.py
+++ b/hellomama_registration/settings.py
@@ -216,9 +216,6 @@ CELERY_ROUTES = {
     'registrations.tasks.repopulate_metrics': {
         'queue': 'mediumpriority',
     },
-    'registrations.tasks.repopulate_metric': {
-        'queue': 'mediumpriority',
-    },
 }
 
 CACHES = {


### PR DESCRIPTION
When running the repopulate metrics tasks with popular production values, it takes 4.5GB of memory before it starts queueing the subtasks. Even if we don't collect all the tasks before hand, and just start queuing them as we generate them, it still takes too much memory.

This PR combines the two tasks to generate metrics into one long running task.