### PR TITLE
Number of conversions from pregnancy to baby metric

### DIFF
--- a/changes/models.py
+++ b/changes/models.py
@@ -78,3 +78,22 @@ def fire_language_change_metric(sender, instance, created, **kwargs):
             'metric_name': total_key,
             'metric_value': total,
         })
+
+
+@receiver(post_save, sender=Change)
+def fire_baby_change_metric(sender, instance, created, **kwargs):
+    from registrations.tasks import fire_metric
+    if created and instance.action == 'change_baby':
+        fire_metric.apply_async(kwargs={
+            "metric_name": 'registrations.change.pregnant_to_baby.sum',
+            "metric_value": 1.0
+        })
+
+        total_key = 'registrations.change.pregnant_to_baby.total.last'
+        total = get_or_incr_cache(
+            total_key,
+            Change.objects.filter(action='change_baby').count)
+        fire_metric.apply_async(kwargs={
+            'metric_name': total_key,
+            'metric_value': total,
+        })

--- a/hellomama_registration/settings.py
+++ b/hellomama_registration/settings.py
@@ -238,7 +238,9 @@ METRICS_REALTIME = [
     'registrations.created.total.last',
     'registrations.unique_operators.sum',
     'registrations.change.language.sum',
-    'registrations.change.language.total.last'
+    'registrations.change.language.total.last',
+    'registrations.change.pregnant_to_baby.sum',
+    'registrations.change.pregnant_to_baby.total.last',
 ]
 METRICS_REALTIME.extend(
     ['registrations.msg_type.%s.sum' % mt for mt in MSG_TYPES])

--- a/registrations/metrics.py
+++ b/registrations/metrics.py
@@ -194,6 +194,19 @@ class MetricGenerator(object):
             .filter(action='change_language')\
             .count()
 
+    def registrations_change_pregnant_to_baby_sum(self, start, end):
+        return Change.objects\
+            .filter(created_at__gt=start)\
+            .filter(created_at__lte=end)\
+            .filter(action='change_baby')\
+            .count()
+
+    def registrations_change_pregnant_to_baby_total_last(self, start, end):
+        return Change.objects\
+            .filter(created_at__lte=end)\
+            .filter(action='change_baby')\
+            .count()
+
 
 def send_metric(amqp_channel, prefix, name, value, timestamp):
     timestamp = utils.timestamp_to_epoch(timestamp)

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -1876,6 +1876,8 @@ class TestMetricsAPI(AuthenticatedAPITestCase):
                 'registrations.source.testadminuser.sum',
                 'registrations.change.language.sum',
                 'registrations.change.language.total.last',
+                'registrations.change.pregnant_to_baby.sum',
+                'registrations.change.pregnant_to_baby.total.last',
             ])
         )
 


### PR DESCRIPTION
This PR implements the "registrations.change.pregnant_to_baby.sum" and "registrations.change.pregnant_to_baby.total.last" metrics