### PR TITLE
Conversions from pregnancy to loss metrics

### DIFF
--- a/changes/tests.py
+++ b/changes/tests.py
@@ -19,7 +19,8 @@ from registrations.models import (
     fire_state_metric, fire_role_metric)
 from .models import (
     Change, change_post_save, fire_language_change_metric,
-    fire_baby_change_metric, fire_message_change_metric)
+    fire_baby_change_metric, fire_loss_change_metric,
+    fire_message_change_metric)
 from .tasks import implement_action
 
 
@@ -50,6 +51,8 @@ class AuthenticatedAPITestCase(APITestCase):
                              sender=Change)
         post_save.disconnect(receiver=fire_baby_change_metric,
                              sender=Change)
+        post_save.disconnect(receiver=fire_loss_change_metric,
+                             sender=Change)
         post_save.disconnect(receiver=fire_message_change_metric,
                              sender=Change)
         post_save.disconnect(receiver=model_saved,
@@ -69,6 +72,8 @@ class AuthenticatedAPITestCase(APITestCase):
         post_save.connect(receiver=fire_language_change_metric,
                           sender=Change)
         post_save.connect(receiver=fire_baby_change_metric,
+                          sender=Change)
+        post_save.connect(receiver=fire_loss_change_metric,
                           sender=Change)
         post_save.connect(receiver=fire_message_change_metric,
                           sender=Change)
@@ -2236,6 +2241,40 @@ class TestMetrics(AuthenticatedAPITestCase):
         })
 
         post_save.disconnect(fire_baby_change_metric, sender=Change)
+
+    @responses.activate
+    def test_loss_change_metric(self):
+        """
+        When a new change is created, a sum metric should be fired if it is a
+        pregnancy to loss change
+        """
+        # deactivate Testsession for this test
+        self.session = None
+        # add metric post response
+        responses.add(responses.POST,
+                      "http://metrics-url/metrics/",
+                      json={"foo": "bar"},
+                      status=200, content_type='application/json')
+        post_save.connect(fire_loss_change_metric, sender=Change)
+
+        change_data = {
+            "mother_id": "846877e6-afaa-43de-acb1-09f61ad4de99",
+            "action": "change_loss",
+            "data": {},
+            "source": self.make_source_adminuser()
+        }
+        Change.objects.create(**change_data)
+
+        [last_call1, last_call2] = responses.calls
+        self.assertEqual(json.loads(last_call1.request.body), {
+            "registrations.change.pregnant_to_loss.sum": 1.0
+        })
+
+        self.assertEqual(json.loads(last_call2.request.body), {
+            "registrations.change.pregnant_to_loss.total.last": 1.0
+        })
+
+        post_save.disconnect(fire_loss_change_metric, sender=Change)
 
     @responses.activate
     def test_message_change_metric(self):

--- a/hellomama_registration/settings.py
+++ b/hellomama_registration/settings.py
@@ -241,6 +241,8 @@ METRICS_REALTIME = [
     'registrations.change.language.total.last',
     'registrations.change.pregnant_to_baby.sum',
     'registrations.change.pregnant_to_baby.total.last',
+    'registrations.change.pregnant_to_loss.sum',
+    'registrations.change.pregnant_to_loss.total.last',
     'registrations.change.messaging.sum',
     'registrations.change.messaging.total.last',
 ]

--- a/registrations/metrics.py
+++ b/registrations/metrics.py
@@ -207,6 +207,19 @@ class MetricGenerator(object):
             .filter(action='change_baby')\
             .count()
 
+    def registrations_change_pregnant_to_loss_sum(self, start, end):
+        return Change.objects\
+            .filter(created_at__gt=start)\
+            .filter(created_at__lte=end)\
+            .filter(action='change_loss')\
+            .count()
+
+    def registrations_change_pregnant_to_loss_total_last(self, start, end):
+        return Change.objects\
+            .filter(created_at__lte=end)\
+            .filter(action='change_loss')\
+            .count()
+
     def registrations_change_messaging_sum(self, start, end):
         return Change.objects\
             .filter(created_at__gt=start)\

--- a/registrations/test_metrics.py
+++ b/registrations/test_metrics.py
@@ -19,7 +19,8 @@ from .models import Source, Registration
 from hellomama_registration import utils
 from changes.models import (
     Change, change_post_save, fire_language_change_metric,
-    fire_baby_change_metric, fire_message_change_metric)
+    fire_baby_change_metric, fire_loss_change_metric,
+    fire_message_change_metric)
 
 
 class MetricsGeneratorTests(AuthenticatedAPITestCase):
@@ -36,6 +37,8 @@ class MetricsGeneratorTests(AuthenticatedAPITestCase):
                              sender=Change)
         post_save.disconnect(receiver=fire_baby_change_metric,
                              sender=Change)
+        post_save.disconnect(receiver=fire_loss_change_metric,
+                             sender=Change)
         post_save.disconnect(receiver=fire_message_change_metric,
                              sender=Change)
         post_save.disconnect(receiver=model_saved,
@@ -50,6 +53,8 @@ class MetricsGeneratorTests(AuthenticatedAPITestCase):
         post_save.connect(receiver=fire_language_change_metric,
                           sender=Change)
         post_save.connect(receiver=fire_baby_change_metric,
+                          sender=Change)
+        post_save.connect(receiver=fire_loss_change_metric,
                           sender=Change)
         post_save.connect(receiver=fire_message_change_metric,
                           sender=Change)
@@ -89,6 +94,9 @@ class MetricsGeneratorTests(AuthenticatedAPITestCase):
 
     def create_baby_change_on(self, timestamp, source, **kwargs):
         return self.create_change_on(timestamp, source, 'change_baby')
+
+    def create_loss_change_on(self, timestamp, source, **kwargs):
+        return self.create_change_on(timestamp, source, 'change_loss')
 
     def create_messaging_change_on(self, timestamp, source, **kwargs):
         return self.create_change_on(timestamp, source, 'change_messaging')
@@ -650,6 +658,58 @@ class MetricsGeneratorTests(AuthenticatedAPITestCase):
 
         change_count = MetricGenerator()\
             .registrations_change_pregnant_to_baby_total_last(start, end)
+        self.assertEqual(change_count, 2)
+
+    def test_change_loss_sum(self):
+        """
+        Should return the amount of pregnancy to loss changes in the given
+        timeframe.
+
+        Only one of the borders of the timeframe should be included, to avoid
+        duplication.
+        """
+
+        user = User.objects.create(username='user1')
+        source = Source.objects.create(
+            name='TestSource', authority='hw_full', user=user)
+
+        start = datetime(2016, 10, 15)
+        end = datetime(2016, 10, 25)
+
+        self.create_loss_change_on(datetime(2016, 10, 14), source)  # Before
+        self.create_loss_change_on(datetime(2016, 10, 15), source)  # On
+        self.create_loss_change_on(datetime(2016, 10, 20), source)  # In
+        self.create_loss_change_on(datetime(2016, 10, 25), source)  # On
+        self.create_loss_change_on(datetime(2016, 10, 26), source)  # After
+
+        # Make sure other change type is not added
+        self.create_messaging_change_on(datetime(2016, 10, 20), source)  # In
+
+        change_count = MetricGenerator()\
+            .registrations_change_pregnant_to_loss_sum(start, end)
+        self.assertEqual(change_count, 2)
+
+    def test_change_loss_total_last(self):
+        """
+        Should return the total amount of pregnancy to loss changes at the
+        'end' point in time.
+        """
+        user = User.objects.create(username='user1')
+        source = Source.objects.create(
+            name='TestSource', authority='hw_full', user=user)
+
+        start = datetime(2016, 10, 15)
+        end = datetime(2016, 10, 25)
+
+        self.create_loss_change_on(datetime(2016, 10, 14), source)  # Before
+        self.create_loss_change_on(datetime(2016, 10, 25), source)  # On
+        self.create_loss_change_on(datetime(2016, 10, 26), source)  # After
+
+        # Make sure other change type is not added
+        self.create_messaging_change_on(datetime(2016, 10, 24), source)  # In
+
+        change_count = MetricGenerator()\
+            .registrations_change_pregnant_to_loss_total_last(start, end)
         self.assertEqual(change_count, 2)
 
     def test_change_message_sum(self):

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -1878,6 +1878,8 @@ class TestMetricsAPI(AuthenticatedAPITestCase):
                 'registrations.change.language.total.last',
                 'registrations.change.pregnant_to_baby.sum',
                 'registrations.change.pregnant_to_baby.total.last',
+                'registrations.change.pregnant_to_loss.sum',
+                'registrations.change.pregnant_to_loss.total.last',
                 'registrations.change.messaging.sum',
                 'registrations.change.messaging.total.last',
             ])


### PR DESCRIPTION
This PR adds the "registrations.change.pregnant_to_loss.sum" and "registrations.change.pregnant_to_loss.total.last" metrics.