### PR TITLE
Add management command for repopulating subscriptions

### DIFF
--- a/registrations/management/commands/repopulate_subscriptions.py
+++ b/registrations/management/commands/repopulate_subscriptions.py
@@ -53,8 +53,9 @@ class Command(BaseCommand):
         registrations = Registration.objects.filter(validated=True)
 
         for reg in registrations:
+            skip = False
             requests = reg.get_subscription_requests()
-            if requests.count() > 0:
+            if requests.exists():
                 continue
             for req in requests:
                 if check_subscription and self.count_subscriptions(client,
@@ -63,7 +64,10 @@ class Command(BaseCommand):
                               'already has subscription (identity: %s). '
                               'Skipping.')
                              % (reg.pk, reg.mother_id))
-                    continue
+                    skip = True
+                    break
+            if skip:
+                continue
 
             """
             validate_registration() ensures no invalid registrations get

--- a/registrations/management/commands/repopulate_subscriptions.py
+++ b/registrations/management/commands/repopulate_subscriptions.py
@@ -74,7 +74,7 @@ class Command(BaseCommand):
             subscriptions and creates the Subscription Request
             """
             output = validate_registration.apply_async(
-                registration_id=str(reg.id))
+                kwargs={"registration_id": str(reg.id)})
             output = output + " (%s)"
             self.log(output % (reg.mother_id))
 

--- a/registrations/management/commands/repopulate_subscriptions.py
+++ b/registrations/management/commands/repopulate_subscriptions.py
@@ -53,20 +53,14 @@ class Command(BaseCommand):
         registrations = Registration.objects.filter(validated=True)
 
         for reg in registrations:
-            skip = False
             requests = reg.get_subscription_requests()
             if requests.exists():
                 continue
-            for req in requests:
-                if check_subscription and self.count_subscriptions(client,
-                                                                   req):
-                    self.log(('Registration %s without Subscription Requests '
-                              'already has subscription (identity: %s). '
-                              'Skipping.')
-                             % (reg.pk, reg.mother_id))
-                    skip = True
-                    break
-            if skip:
+            if check_subscription and self.count_subscriptions(client, reg):
+                self.log(('Registration %s without Subscription Requests '
+                          'already has subscription (identity: %s). '
+                          'Skipping.')
+                         % (reg.pk, reg.mother_id))
                 continue
 
             """
@@ -81,8 +75,8 @@ class Command(BaseCommand):
     def log(self, log):
         self.stdout.write('%s\n' % (log,))
 
-    def count_subscriptions(self, sbm_client, subscription_request):
+    def count_subscriptions(self, sbm_client, registration):
         subscriptions = sbm_client.get_subscriptions({
-            'identity': subscription_request.identity,
+            'identity': registration.mother_id,
         })
         return int(subscriptions['count'])

--- a/registrations/management/commands/repopulate_subscriptions.py
+++ b/registrations/management/commands/repopulate_subscriptions.py
@@ -73,7 +73,8 @@ class Command(BaseCommand):
             validate_registration() ensures no invalid registrations get
             subscriptions and creates the Subscription Request
             """
-            output = validate_registration(registration_id=str(reg.id))
+            output = validate_registration.apply_async(
+                registration_id=str(reg.id))
             output = output + " (%s)"
             self.log(output % (reg.mother_id))
 

--- a/registrations/management/commands/repopulate_subscriptions.py
+++ b/registrations/management/commands/repopulate_subscriptions.py
@@ -1,0 +1,83 @@
+from os import environ
+
+from django.core.management.base import BaseCommand, CommandError
+
+from registrations.models import Registration
+from registrations.tasks import validate_registration
+
+from seed_services_client import StageBasedMessagingApiClient
+
+from ._utils import validate_and_return_url
+
+
+class Command(BaseCommand):
+    help = ("Validates all Registrations without Subscription Requests and "
+            "creates one for each. This should also lead to the creation of a "
+            "Subscription in the SMB service")
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--blind', action='store_false', default=True,
+            dest='check_subscription',
+            help=('Do not check with the stage based messaging API whether'
+                  'or not a subscription for the identity already exists.'
+                  'NOT RECOMMENDED AT ALL'))
+        parser.add_argument(
+            '--sbm-url', dest='sbm_url', type=validate_and_return_url,
+            default=environ.get('STAGE_BASED_MESSAGING_URL'),
+            help=('The Stage Based Messaging Service to verify '
+                  'subscriptions for.'))
+        parser.add_argument(
+            '--sbm-token', dest='sbm_token',
+            default=environ.get('STAGE_BASED_MESSAGING_TOKEN'),
+            help=('The Authorization token for the SBM Service')
+        )
+
+    def handle(self, *args, **kwargs):
+        sbm_url = kwargs['sbm_url']
+        sbm_token = kwargs['sbm_token']
+        check_subscription = kwargs['check_subscription']
+
+        if check_subscription:
+            if not sbm_url:
+                raise CommandError(
+                    'Please make sure either the STAGE_BASED_MESSAGING_URL '
+                    'environment variable or --sbm-url is set.')
+
+            if not sbm_token:
+                raise CommandError(
+                    'Please make sure either the STAGE_BASED_MESSAGING_TOKEN '
+                    'environment variable or --sbm-token is set.')
+            client = StageBasedMessagingApiClient(sbm_token, sbm_url)
+
+        registrations = Registration.objects.filter(validated=True)
+
+        for reg in registrations:
+            requests = reg.get_subscription_requests()
+            if requests.count() > 0:
+                continue
+            for req in requests:
+                if check_subscription and self.count_subscriptions(client,
+                                                                   req):
+                    self.log(('Registration %s without Subscription Requests '
+                              'already has subscription (identity: %s). '
+                              'Skipping.')
+                             % (reg.pk, reg.mother_id))
+                    continue
+
+            """
+            validate_registration() ensures no invalid registrations get
+            subscriptions and creates the Subscription Request
+            """
+            output = validate_registration(registration_id=str(reg.id))
+            output = output + " (%s)"
+            self.log(output % (reg.mother_id))
+
+    def log(self, log):
+        self.stdout.write('%s\n' % (log,))
+
+    def count_subscriptions(self, sbm_client, subscription_request):
+        subscriptions = sbm_client.get_subscriptions({
+            'identity': subscription_request.identity,
+        })
+        return int(subscriptions['count'])

--- a/registrations/management/commands/repopulate_subscriptions.py
+++ b/registrations/management/commands/repopulate_subscriptions.py
@@ -76,7 +76,11 @@ class Command(BaseCommand):
         self.stdout.write('%s\n' % (log,))
 
     def count_subscriptions(self, sbm_client, registration):
-        subscriptions = sbm_client.get_subscriptions({
-            'identity': registration.mother_id,
-        })
-        return int(subscriptions['count'])
+        receivers = registration.get_receiver_ids()
+        count = 0
+        for receiver in receivers:
+            subscriptions = sbm_client.get_subscriptions({
+                'identity': receiver,
+            })
+            count += int(subscriptions['count'])
+        return count

--- a/registrations/test_commands.py
+++ b/registrations/test_commands.py
@@ -1,0 +1,127 @@
+import responses
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+from django.core import management
+
+from .models import Registration, SubscriptionRequest
+from .tests import AuthenticatedAPITestCase, REG_DATA
+
+
+class ManagementCommandsTests(AuthenticatedAPITestCase):
+    def test_command_requires_sbm_url(self):
+        with self.assertRaises(management.CommandError) as ce:
+            management.call_command("repopulate_subscriptions")
+        self.assertEqual(
+            ce.exception.message, "Please make sure either the "
+            "STAGE_BASED_MESSAGING_URL environment variable or --sbm-url is "
+            "set.")
+
+    def test_command_requires_sbm_token(self):
+        with self.assertRaises(management.CommandError) as ce:
+            management.call_command("repopulate_subscriptions",
+                                    sbm_url="http://example.com")
+        self.assertEqual(
+            ce.exception.message, "Please make sure either the "
+            "STAGE_BASED_MESSAGING_TOKEN environment variable or --sbm-token "
+            "is set.")
+
+    @responses.activate
+    @mock.patch("registrations.tasks.validate_registration.apply_async")
+    def test_command_successful(self, mock_validation):
+        # prepare registration data
+        registration_data = {
+            "stage": "prebirth",
+            "mother_id": "mother00-9d89-4aa6-99ff-13c225365b5d",
+            "data": REG_DATA["hw_pre_mother"].copy(),
+            "source": self.make_source_adminuser(),
+            "validated": True
+        }
+        registration = Registration.objects.create(**registration_data)
+        self.assertFalse(SubscriptionRequest.objects.all().exists())
+
+        responses.add(
+            responses.GET,
+            'http://localhost:8005/api/v1/subscriptions/?identity=%s' %
+            registration.mother_id,
+            json={
+                "count": 0,
+                "next": None,
+                "previous": None,
+                "results": []
+            },
+            status=200, content_type='application/json',
+            match_querystring=True
+        )
+
+        management.call_command("repopulate_subscriptions",
+                                sbm_url="http://localhost:8005/api/v1",
+                                sbm_token="test_token")
+        mock_validation.assert_called_once_with(
+            kwargs={"registration_id": str(registration.id)})
+
+    @mock.patch("registrations.tasks.validate_registration.apply_async")
+    def test_command_subscription_requests_found(self, mock_validation):
+        registration_data = {
+            "stage": "prebirth",
+            "mother_id": "mother00-9d89-4aa6-99ff-13c225365b5d",
+            "data": REG_DATA["hw_pre_mother"].copy(),
+            "source": self.make_source_adminuser(),
+            "validated": True
+        }
+        registration = Registration.objects.create(**registration_data)
+        SubscriptionRequest.objects.create(
+            identity=str(registration.mother_id), messageset=3,
+            next_sequence_number=2, lang="eng_ZA")
+
+        management.call_command("repopulate_subscriptions",
+                                sbm_url="http://localhost:8005/api/v1",
+                                sbm_token="test_token")
+        mock_validation.assert_not_called()
+
+    @responses.activate
+    @mock.patch("registrations.tasks.validate_registration.apply_async")
+    def test_command_subscriptions_found(self, mock_validation):
+        # prepare registration data
+        registration_data = {
+            "stage": "prebirth",
+            "mother_id": "mother00-9d89-4aa6-99ff-13c225365b5d",
+            "data": REG_DATA["hw_pre_mother"].copy(),
+            "source": self.make_source_adminuser(),
+            "validated": True
+        }
+        registration = Registration.objects.create(**registration_data)
+        self.assertFalse(SubscriptionRequest.objects.all().exists())
+
+        responses.add(
+            responses.GET,
+            'http://localhost:8005/api/v1/subscriptions/?identity=%s' %
+            registration.mother_id,
+            json={
+                "count": 1,
+                "next": None,
+                "previous": None,
+                "results": [{
+                    "id": "b0afe9fb-0b4d-478e-974e-6b794e69cc6e",
+                    "version": 1,
+                    "identity": "mother00-9d89-4aa6-99ff-13c225365b5d",
+                    "messageset": 1,
+                    "next_sequence_number": 1,
+                    "lang": "eng",
+                    "active": True,
+                    "completed": False,
+                    "schedule": 1,
+                    "process_status": 0,
+                    "metadata": None,
+                }]
+            },
+            status=200, content_type='application/json',
+            match_querystring=True
+        )
+
+        management.call_command("repopulate_subscriptions",
+                                sbm_url="http://localhost:8005/api/v1",
+                                sbm_token="test_token")
+        mock_validation.assert_not_called()

--- a/registrations/test_commands.py
+++ b/registrations/test_commands.py
@@ -15,7 +15,7 @@ class ManagementCommandsTests(AuthenticatedAPITestCase):
         with self.assertRaises(management.CommandError) as ce:
             management.call_command("repopulate_subscriptions")
         self.assertEqual(
-            ce.exception.message, "Please make sure either the "
+            str(ce.exception), "Please make sure either the "
             "STAGE_BASED_MESSAGING_URL environment variable or --sbm-url is "
             "set.")
 
@@ -24,7 +24,7 @@ class ManagementCommandsTests(AuthenticatedAPITestCase):
             management.call_command("repopulate_subscriptions",
                                     sbm_url="http://example.com")
         self.assertEqual(
-            ce.exception.message, "Please make sure either the "
+            str(ce.exception), "Please make sure either the "
             "STAGE_BASED_MESSAGING_TOKEN environment variable or --sbm-token "
             "is set.")
 


### PR DESCRIPTION
There have been a number of bugs that have prevented registrations from being converted into subscriptions (the most recent being incorrect message set names). These bugs have been fixed and this PR adds a management command to re-run the validation on registrations that don't have subscriptions. This will result in the subscriptions being created.