### PR TITLE
Add http retries for metric repopulation

### DIFF
--- a/hellomama_registration/utils.py
+++ b/hellomama_registration/utils.py
@@ -48,7 +48,7 @@ def get_identity(identity):
         'Authorization': 'Token %s' % settings.IDENTITY_STORE_TOKEN,
         'Content-Type': 'application/json'
     }
-    r = requests.get(url, headers=headers)
+    r = session.get(url, headers=headers)
     return r.json()
 
 
@@ -60,7 +60,7 @@ def get_identity_address(identity):
         'Authorization': 'Token %s' % settings.IDENTITY_STORE_TOKEN,
         'Content-Type': 'application/json'
     }
-    r = requests.get(url, params=params, headers=headers).json()
+    r = session.get(url, params=params, headers=headers).json()
     if len(r["results"]) > 0:
         return r["results"][0]["address"]
     else:
@@ -99,7 +99,7 @@ def patch_identity(identity, data):
         'Authorization': 'Token %s' % settings.IDENTITY_STORE_TOKEN,
         'Content-Type': 'application/json'
     }
-    r = requests.patch(url, data=json.dumps(data), headers=headers)
+    r = session.patch(url, data=json.dumps(data), headers=headers)
     r.raise_for_status()
     return r.json()
 
@@ -111,7 +111,7 @@ def get_messageset_by_shortname(short_name):
         'Authorization': 'Token %s' % settings.STAGE_BASED_MESSAGING_TOKEN,
         'Content-Type': 'application/json'
     }
-    r = requests.get(url, params=params, headers=headers)
+    r = session.get(url, params=params, headers=headers)
     return r.json()["results"][0]  # messagesets should be unique, return 1st
 
 
@@ -122,7 +122,7 @@ def get_messageset(messageset_id):
         'Authorization': 'Token %s' % settings.STAGE_BASED_MESSAGING_TOKEN,
         'Content-Type': 'application/json'
     }
-    r = requests.get(url, headers=headers)
+    r = session.get(url, headers=headers)
     return r.json()
 
 
@@ -133,7 +133,7 @@ def get_schedule(schedule_id):
         'Authorization': 'Token %s' % settings.STAGE_BASED_MESSAGING_TOKEN,
         'Content-Type': 'application/json'
     }
-    r = requests.get(url, headers=headers)
+    r = session.get(url, headers=headers)
     return r.json()
 
 
@@ -146,7 +146,7 @@ def get_subscriptions(identity):
         'Authorization': 'Token %s' % settings.STAGE_BASED_MESSAGING_TOKEN,
         'Content-Type': 'application/json'
     }
-    r = requests.get(url, params=params, headers=headers)
+    r = session.get(url, params=params, headers=headers)
     return r.json()["results"]
 
 
@@ -161,7 +161,7 @@ def patch_subscription(subscription, data):
         'Token %s' % settings.STAGE_BASED_MESSAGING_TOKEN,
         'Content-Type': 'application/json'
     }
-    r = requests.patch(url, data=data, headers=headers)
+    r = session.patch(url, data=data, headers=headers)
     return r.json()
 
 
@@ -235,7 +235,7 @@ def get_messageset_schedule_sequence(short_name, weeks):
 
 
 def post_message(payload):
-    result = requests.post(
+    result = session.post(
         url="%s/outbound/" % settings.MESSAGE_SENDER_URL,
         data=json.dumps(payload),
         headers={

--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -360,7 +360,16 @@ class RepopulateMetrics(Task):
         """
         Generates the value for the specified metric, and sends it.
         """
-        value = MetricGenerator().generate_metric(metric_name, start, end)
+        try:
+            value = MetricGenerator().generate_metric(metric_name, start, end)
+        except requests.exceptions.RequestException:
+            # If we have an issue contacting an external service for this
+            # metric, just skip it.
+            return
+        except ValueError:
+            # If an external service doesn't return an valid JSON response for
+            # this metric, just skip it.
+            return
 
         timestamp = start + (end - start) / 2
         send_metric(amqp_url, prefix, metric_name, value, timestamp)


### PR DESCRIPTION
Currently, the metric repopulation task fails if one of the HTTP requests to one of the external services fails. We should retry failed requests a number of times, and if we still can't get through, we should just skip that metric instead of failing the whole task.