### PR TITLE
Enable correcting postbirth or old prebirth subscriptions

### DIFF
--- a/registrations/management/commands/fix_registration_subscriptions.py
+++ b/registrations/management/commands/fix_registration_subscriptions.py
@@ -1,5 +1,5 @@
 from os import environ
-from datetime import datetime
+import datetime
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
@@ -32,8 +32,8 @@ class Command(BaseCommand):
             help=("Attempt to automatically fix the subscriptions and "
                   "requests if they turn out to be wrong"))
         parser.add_argument(
-            "--today", dest="today", default=datetime.now(),
-            type=lambda today: datetime.strptime(today, '%Y%m%d'),
+            "--today", dest="today", default=datetime.datetime.now(),
+            type=lambda today: datetime.datetime.strptime(today, '%Y%m%d'),
             help=("Set the date for 'today' from which to calculate the "
                   "next_sequence_number value. By default it will use "
                   "datetime.now() (format YYYYMMDD)")

--- a/registrations/management/commands/fix_registration_subscriptions.py
+++ b/registrations/management/commands/fix_registration_subscriptions.py
@@ -173,6 +173,13 @@ class Command(BaseCommand):
                 self.create_subscription_request(
                     registration, receiver_id, messageset_id, schedule_id,
                     next_sequence_number)
+            else:
+                # return temp subscription request for checking subscriptions
+                return [SubscriptionRequest(
+                    identity=receiver_id, messageset=messageset_id,
+                    next_sequence_number=next_sequence_number,
+                    lang=registration.data["language"], schedule=schedule_id,
+                    metadata={})]
 
         data = {
             'next_sequence_number': next_sequence_number,

--- a/registrations/management/commands/fix_registration_subscriptions.py
+++ b/registrations/management/commands/fix_registration_subscriptions.py
@@ -322,13 +322,6 @@ class Command(BaseCommand):
                 'This registration is not valid. This command only works with '
                 'validated registrations')
 
-        # TODO: Handle fixing of post-birth message sets
-        if registration.stage != 'prebirth':
-            raise CommandError(
-                'This command has not been confirmed to work with any stage '
-                'other than prebirth, this registration is: %s' % (
-                    registration.stage))
-
         weeks = registration.estimate_current_preg_weeks(today=today)
         if weeks > settings.PREBIRTH_MAX_WEEKS + settings.POSTBIRTH_MAX_WEEKS:
             raise CommandError(

--- a/registrations/management/commands/fix_registration_subscriptions.py
+++ b/registrations/management/commands/fix_registration_subscriptions.py
@@ -329,12 +329,11 @@ class Command(BaseCommand):
                 'other than prebirth, this registration is: %s' % (
                     registration.stage))
 
-        # TODO: Handle conversion to post-birth message sets
         weeks = registration.estimate_current_preg_weeks(today=today)
-        if weeks > settings.PREBIRTH_MAX_WEEKS:
+        if weeks > settings.PREBIRTH_MAX_WEEKS + settings.POSTBIRTH_MAX_WEEKS:
             raise CommandError(
                 'This pregnancy is %s weeks old and should no longer be on '
-                'the prebirth message sets' % (weeks))
+                'any of our message sets' % (weeks))
 
         if not sbm_url:
             raise CommandError(


### PR DESCRIPTION
The management command to correct registration subscriptions only works for postbirth registrations where the mother is still pregnant. This will make it work for older prebirth registrations and postbirth registrations