### PR TITLE
Allow for multiple registrations per msisdn on changes

### DIFF
--- a/changes/tasks.py
+++ b/changes/tasks.py
@@ -19,7 +19,9 @@ class ImplementAction(Task):
         # Get mother's identity
         mother = utils.get_identity(change.mother_id)
         # Get mother's registration
-        registration = Registration.objects.get(mother_id=change.mother_id)
+        registrations = Registration.objects.\
+            filter(mother_id=change.mother_id, stage='prebirth').\
+            order_by('-created_at')
 
         stage = 'postbirth'
         weeks = 0
@@ -44,21 +46,23 @@ class ImplementAction(Task):
         SubscriptionRequest.objects.create(**mother_sub)
 
         # Make household subscription if required
-        if registration.data["msg_receiver"] != 'mother_only':
-            household_short_name = utils.get_messageset_short_name(
-                stage, 'household', mother["details"]["preferred_msg_type"],
-                weeks, "fri", "9_11")
-            household_msgset_id, household_msgset_schedule, seq_number =\
-                utils.get_messageset_schedule_sequence(
-                    household_short_name, weeks)
-            household_sub = {
-                "identity": mother["details"]["linked_to"],
-                "messageset": household_msgset_id,
-                "next_sequence_number": seq_number,
-                "lang": mother["details"]["preferred_language"],
-                "schedule": household_msgset_schedule
-            }
-            SubscriptionRequest.objects.create(**household_sub)
+        for registration in registrations:
+            if registration.data["msg_receiver"] != 'mother_only':
+                household_short_name = utils.get_messageset_short_name(
+                    stage, 'household', mother["details"]
+                    ["preferred_msg_type"], weeks, "fri", "9_11")
+                household_msgset_id, household_msgset_schedule, seq_number =\
+                    utils.get_messageset_schedule_sequence(
+                        household_short_name, weeks)
+                household_sub = {
+                    "identity": mother["details"]["linked_to"],
+                    "messageset": household_msgset_id,
+                    "next_sequence_number": seq_number,
+                    "lang": mother["details"]["preferred_language"],
+                    "schedule": household_msgset_schedule
+                }
+                SubscriptionRequest.objects.create(**household_sub)
+            break
 
         return "Change baby completed"
 
@@ -94,14 +98,18 @@ class ImplementAction(Task):
         SubscriptionRequest.objects.create(**mother_sub)
 
         # Get mother's registration
-        registration = Registration.objects.get(mother_id=change.mother_id)
-        if registration.data["msg_receiver"] != 'mother_only':
-            # Get household's current subscriptions
-            subscriptions = utils.get_subscriptions(
-                mother["details"]["linked_to"])
-            # Deactivate subscriptions
-            for subscription in subscriptions:
-                utils.deactivate_subscription(subscription)
+        registrations = Registration.objects.\
+            filter(mother_id=change.mother_id, stage='prebirth').\
+            order_by('-created_at')
+        for registration in registrations:
+            if registration.data["msg_receiver"] != 'mother_only':
+                # Get household's current subscriptions
+                subscriptions = utils.get_subscriptions(
+                    mother["details"]["linked_to"])
+                # Deactivate subscriptions
+                for subscription in subscriptions:
+                    utils.deactivate_subscription(subscription)
+            break
 
         return "Change loss completed"
 

--- a/changes/tests.py
+++ b/changes/tests.py
@@ -1665,7 +1665,6 @@ class TestChangeBaby(AuthenticatedAPITestCase):
     def test_friend_only_change_baby(self):
         # Setup
         # make registration
-        self.make_registration_mother_only()
         self.make_registration_friend_only()
         # make change object
         change_data = {

--- a/changes/tests.py
+++ b/changes/tests.py
@@ -1451,6 +1451,112 @@ class TestChangeMessaging(AuthenticatedAPITestCase):
 class TestChangeBaby(AuthenticatedAPITestCase):
 
     @responses.activate
+    def test_change_baby_multiple_registrations(self):
+        # Setup
+        # make registration
+        self.make_registration_mother_only()
+        self.make_registration_mother_only()
+        # make change object
+        change_data = {
+            "mother_id": "846877e6-afaa-43de-acb1-09f61ad4de99",
+            "action": "change_baby",
+            "data": {},
+            "source": self.make_source_adminuser()
+        }
+        change = Change.objects.create(**change_data)
+        # mock get subscription request
+        subscription_id = "07f4d95c-ad78-4bf1-8779-c47b428e89d0"
+        query_string = '?active=True&id=%s' % change_data["mother_id"]
+        responses.add(
+            responses.GET,
+            'http://localhost:8005/api/v1/subscriptions/%s' % query_string,
+            json={
+                "count": 1,
+                "next": None,
+                "previous": None,
+                "results": [{
+                    "id": subscription_id,
+                    "identity": change_data["mother_id"],
+                    "active": True,
+                    "lang": "eng_NG"
+                }],
+            },
+            status=200, content_type='application/json',
+            match_querystring=True
+        )
+        # mock patch subscription request
+        responses.add(
+            responses.PATCH,
+            'http://localhost:8005/api/v1/subscriptions/%s/' % subscription_id,
+            json={"active": False},
+            status=200, content_type='application/json',
+        )
+        # mock identity lookup
+        responses.add(
+            responses.GET,
+            'http://localhost:8001/api/v1/identities/%s/' % change_data[
+                "mother_id"],
+            json={
+                "id": change_data["mother_id"],
+                "version": 1,
+                "details": {
+                    "default_addr_type": "msisdn",
+                    "addresses": {
+                        "msisdn": {
+                            "+2345059992222": {}
+                        }
+                    },
+                    "receiver_role": "mother",
+                    "linked_to": None,
+                    "preferred_msg_type": "audio",
+                    "preferred_msg_days": "mon_wed",
+                    "preferred_msg_times": "9_11",
+                    "preferred_language": "hau_NG"
+                },
+                "created_at": "2015-07-10T06:13:29.693272Z",
+                "updated_at": "2015-07-10T06:13:29.693298Z"
+            },
+            status=200, content_type='application/json',
+        )
+        # mock mother messageset lookup
+        query_string = '?short_name=postbirth.mother.audio.0_12.mon_wed.9_11'
+        responses.add(
+            responses.GET,
+            'http://localhost:8005/api/v1/messageset/%s' % query_string,
+            json={
+                "count": 1,
+                "next": None,
+                "previous": None,
+                "results": [{
+                    "id": 2,
+                    "short_name": 'postbirth.mother.audio.0_12.mon_wed.9_11',
+                    "default_schedule": 4
+                }]
+            },
+            status=200, content_type='application/json',
+            match_querystring=True
+        )
+        # mock mother schedule lookup
+        responses.add(
+            responses.GET,
+            'http://localhost:8005/api/v1/schedule/4/',
+            json={"id": 4, "day_of_week": "1,3"},
+            status=200, content_type='application/json',
+        )
+
+        # Execute
+        result = implement_action.apply_async(args=[change.id])
+
+        # Check
+        self.assertEqual(result.get(), "Change baby completed")
+        d = SubscriptionRequest.objects.last()
+        self.assertEqual(d.identity, "846877e6-afaa-43de-acb1-09f61ad4de99")
+        self.assertEqual(d.messageset, 2)
+        self.assertEqual(d.next_sequence_number, 1)
+        self.assertEqual(d.lang, "hau_NG")
+        self.assertEqual(d.schedule, 4)
+
+    @responses.activate
     def test_mother_only_change_baby(self):
         # Setup
         # make registration
@@ -1559,6 +1665,7 @@ class TestChangeBaby(AuthenticatedAPITestCase):
     def test_friend_only_change_baby(self):
         # Setup
         # make registration
+        self.make_registration_mother_only()
         self.make_registration_friend_only()
         # make change object
         change_data = {
@@ -1938,6 +2045,112 @@ class TestChangeUnsubscribeMother(AuthenticatedAPITestCase):
 
 
 class TestChangeLoss(AuthenticatedAPITestCase):
+
+    @responses.activate
+    def test_change_loss_multiple_registrations(self):
+        # Setup
+        # make registration
+        self.make_registration_mother_only()
+        self.make_registration_mother_only()
+        # make change object
+        change_data = {
+            "mother_id": "846877e6-afaa-43de-acb1-09f61ad4de99",
+            "action": "change_loss",
+            "data": {"reason": "miscarriage"},
+            "source": self.make_source_adminuser()
+        }
+        change = Change.objects.create(**change_data)
+        # mock get subscription request
+        subscription_id = "07f4d95c-ad78-4bf1-8779-c47b428e89d0"
+        query_string = '?active=True&id=%s' % change_data["mother_id"]
+        responses.add(
+            responses.GET,
+            'http://localhost:8005/api/v1/subscriptions/%s' % query_string,
+            json={
+                "count": 1,
+                "next": None,
+                "previous": None,
+                "results": [{
+                    "id": subscription_id,
+                    "identity": change_data["mother_id"],
+                    "active": True,
+                    "lang": "eng_NG"
+                }],
+            },
+            status=200, content_type='application/json',
+            match_querystring=True
+        )
+        # mock patch subscription request
+        responses.add(
+            responses.PATCH,
+            'http://localhost:8005/api/v1/subscriptions/%s/' % subscription_id,
+            json={"active": False},
+            status=200, content_type='application/json',
+        )
+        # mock identity lookup
+        responses.add(
+            responses.GET,
+            'http://localhost:8001/api/v1/identities/%s/' % change_data[
+                "mother_id"],
+            json={
+                "id": change_data["mother_id"],
+                "version": 1,
+                "details": {
+                    "default_addr_type": "msisdn",
+                    "addresses": {
+                        "msisdn": {
+                            "+2345059992222": {}
+                        }
+                    },
+                    "receiver_role": "mother",
+                    "linked_to": None,
+                    "preferred_msg_type": "audio",
+                    "preferred_msg_days": "mon_wed",
+                    "preferred_msg_times": "9_11",
+                    "preferred_language": "hau_NG"
+                },
+                "created_at": "2015-07-10T06:13:29.693272Z",
+                "updated_at": "2015-07-10T06:13:29.693298Z"
+            },
+            status=200, content_type='application/json',
+        )
+        # mock mother messageset lookup
+        query_string = '?short_name=miscarriage.mother.audio.0_2.mon_wed.9_11'
+        responses.add(
+            responses.GET,
+            'http://localhost:8005/api/v1/messageset/%s' % query_string,
+            json={
+                "count": 1,
+                "next": None,
+                "previous": None,
+                "results": [{
+                    "id": 19,
+                    "short_name": 'miscarriage.mother.audio.0_2.mon_wed.9_11',
+                    "default_schedule": 4
+                }]
+            },
+            status=200, content_type='application/json',
+            match_querystring=True
+        )
+        # mock mother schedule lookup
+        responses.add(
+            responses.GET,
+            'http://localhost:8005/api/v1/schedule/4/',
+            json={"id": 4, "day_of_week": "1,3"},
+            status=200, content_type='application/json',
+        )
+
+        # Execute
+        result = implement_action.apply_async(args=[change.id])
+
+        # Check
+        self.assertEqual(result.get(), "Change loss completed")
+        d = SubscriptionRequest.objects.last()
+        self.assertEqual(d.identity, "846877e6-afaa-43de-acb1-09f61ad4de99")
+        self.assertEqual(d.messageset, 19)
+        self.assertEqual(d.next_sequence_number, 1)
+        self.assertEqual(d.lang, "hau_NG")
+        self.assertEqual(d.schedule, 4)
 
     @responses.activate
     def test_mother_only_change_loss(self):


### PR DESCRIPTION
The baby change is failing on Prod because some identities have multiple registrations, the code need to get the latest relevant registration.
