### PR TITLE
Fixed changes for text message sets

### DIFF
--- a/changes/tasks.py
+++ b/changes/tasks.py
@@ -25,8 +25,8 @@ class ImplementAction(Task):
 
         stage = 'postbirth'
         weeks = 0
-        voice_days = mother["details"]["preferred_msg_days"]
-        voice_times = mother["details"]["preferred_msg_times"]
+        voice_days = mother["details"].get("preferred_msg_days")
+        voice_times = mother["details"].get("preferred_msg_times")
 
         mother_short_name = utils.get_messageset_short_name(
             stage, 'mother', mother["details"]["preferred_msg_type"],
@@ -77,8 +77,8 @@ class ImplementAction(Task):
 
         stage = 'miscarriage'
         weeks = 0
-        voice_days = mother["details"]["preferred_msg_days"]
-        voice_times = mother["details"]["preferred_msg_times"]
+        voice_days = mother["details"].get("preferred_msg_days")
+        voice_times = mother["details"].get("preferred_msg_times")
 
         mother_short_name = utils.get_messageset_short_name(
             stage, 'mother', mother["details"]["preferred_msg_type"],

--- a/changes/tests.py
+++ b/changes/tests.py
@@ -1801,6 +1801,109 @@ class TestChangeBaby(AuthenticatedAPITestCase):
         self.assertEqual(d_hh.lang, "hau_NG")
         self.assertEqual(d_hh.schedule, 3)
 
+    @responses.activate
+    def test_mother_only_change_baby_text(self):
+        # Setup
+        # make registration
+        self.make_registration_mother_only()
+        # make change object
+        change_data = {
+            "mother_id": "846877e6-afaa-43de-acb1-09f61ad4de99",
+            "action": "change_baby",
+            "data": {},
+            "source": self.make_source_adminuser()
+        }
+        change = Change.objects.create(**change_data)
+        # mock get subscription request
+        subscription_id = "07f4d95c-ad78-4bf1-8779-c47b428e89d0"
+        query_string = '?active=True&id=%s' % change_data["mother_id"]
+        responses.add(
+            responses.GET,
+            'http://localhost:8005/api/v1/subscriptions/%s' % query_string,
+            json={
+                "count": 1,
+                "next": None,
+                "previous": None,
+                "results": [{
+                    "id": subscription_id,
+                    "identity": change_data["mother_id"],
+                    "active": True,
+                    "lang": "eng_NG"
+                }],
+            },
+            status=200, content_type='application/json',
+            match_querystring=True
+        )
+        # mock patch subscription request
+        responses.add(
+            responses.PATCH,
+            'http://localhost:8005/api/v1/subscriptions/%s/' % subscription_id,
+            json={"active": False},
+            status=200, content_type='application/json',
+        )
+        # mock identity lookup
+        responses.add(
+            responses.GET,
+            'http://localhost:8001/api/v1/identities/%s/' % change_data[
+                "mother_id"],
+            json={
+                "id": change_data["mother_id"],
+                "version": 1,
+                "details": {
+                    "default_addr_type": "msisdn",
+                    "addresses": {
+                        "msisdn": {
+                            "+2345059992222": {}
+                        }
+                    },
+                    "receiver_role": "mother",
+                    "linked_to": None,
+                    "preferred_msg_type": "text",
+                    "preferred_language": "hau_NG"
+                },
+                "created_at": "2015-07-10T06:13:29.693272Z",
+                "updated_at": "2015-07-10T06:13:29.693298Z"
+            },
+            status=200, content_type='application/json',
+        )
+        # mock mother messageset lookup
+        query_string = '?short_name=postbirth.mother.text.0_12'
+        responses.add(
+            responses.GET,
+            'http://localhost:8005/api/v1/messageset/%s' % query_string,
+            json={
+                "count": 1,
+                "next": None,
+                "previous": None,
+                "results": [{
+                    "id": 7,
+                    "short_name": 'postbirth.mother.text.0_12',
+                    "default_schedule": 1
+                }]
+            },
+            status=200, content_type='application/json',
+            match_querystring=True
+        )
+        # mock mother schedule lookup
+        responses.add(
+            responses.GET,
+            'http://localhost:8005/api/v1/schedule/1/',
+            json={"id": 1, "day_of_week": "1,3"},
+            status=200, content_type='application/json',
+        )
+
+        # Execute
+        result = implement_action.apply_async(args=[change.id])
+
+        # Check
+        self.assertEqual(result.get(), "Change baby completed")
+        d = SubscriptionRequest.objects.last()
+        self.assertEqual(d.identity, "846877e6-afaa-43de-acb1-09f61ad4de99")
+        self.assertEqual(d.messageset, 7)
+        self.assertEqual(d.next_sequence_number, 1)
+        self.assertEqual(d.lang, "hau_NG")
+        self.assertEqual(d.schedule, 1)
+
 
 class TestChangeLanguage(AuthenticatedAPITestCase):
 
@@ -2388,6 +2491,109 @@ class TestChangeLoss(AuthenticatedAPITestCase):
         self.assertEqual(d.next_sequence_number, 1)
         self.assertEqual(d.lang, "hau_NG")
         self.assertEqual(d.schedule, 4)
+
+    @responses.activate
+    def test_mother_only_change_loss_text(self):
+        # Setup
+        # make registration
+        self.make_registration_mother_only()
+        # make change object
+        change_data = {
+            "mother_id": "846877e6-afaa-43de-acb1-09f61ad4de99",
+            "action": "change_loss",
+            "data": {"reason": "miscarriage"},
+            "source": self.make_source_adminuser()
+        }
+        change = Change.objects.create(**change_data)
+        # mock get subscription request
+        subscription_id = "07f4d95c-ad78-4bf1-8779-c47b428e89d0"
+        query_string = '?active=True&id=%s' % change_data["mother_id"]
+        responses.add(
+            responses.GET,
+            'http://localhost:8005/api/v1/subscriptions/%s' % query_string,
+            json={
+                "count": 1,
+                "next": None,
+                "previous": None,
+                "results": [{
+                    "id": subscription_id,
+                    "identity": change_data["mother_id"],
+                    "active": True,
+                    "lang": "eng_NG"
+                }],
+            },
+            status=200, content_type='application/json',
+            match_querystring=True
+        )
+        # mock patch subscription request
+        responses.add(
+            responses.PATCH,
+            'http://localhost:8005/api/v1/subscriptions/%s/' % subscription_id,
+            json={"active": False},
+            status=200, content_type='application/json',
+        )
+        # mock identity lookup
+        responses.add(
+            responses.GET,
+            'http://localhost:8001/api/v1/identities/%s/' % change_data[
+                "mother_id"],
+            json={
+                "id": change_data["mother_id"],
+                "version": 1,
+                "details": {
+                    "default_addr_type": "msisdn",
+                    "addresses": {
+                        "msisdn": {
+                            "+2345059992222": {}
+                        }
+                    },
+                    "receiver_role": "mother",
+                    "linked_to": None,
+                    "preferred_msg_type": "text",
+                    "preferred_language": "hau_NG"
+                },
+                "created_at": "2015-07-10T06:13:29.693272Z",
+                "updated_at": "2015-07-10T06:13:29.693298Z"
+            },
+            status=200, content_type='application/json',
+        )
+        # mock mother messageset lookup
+        query_string = '?short_name=miscarriage.mother.text.0_2'
+        responses.add(
+            responses.GET,
+            'http://localhost:8005/api/v1/messageset/%s' % query_string,
+            json={
+                "count": 1,
+                "next": None,
+                "previous": None,
+                "results": [{
+                    "id": 18,
+                    "short_name": 'miscarriage.mother.text.0_2',
+                    "default_schedule": 1
+                }]
+            },
+            status=200, content_type='application/json',
+            match_querystring=True
+        )
+        # mock mother schedule lookup
+        responses.add(
+            responses.GET,
+            'http://localhost:8005/api/v1/schedule/1/',
+            json={"id": 1, "day_of_week": "0,2"},
+            status=200, content_type='application/json',
+        )
+
+        # Execute
+        result = implement_action.apply_async(args=[change.id])
+
+        # Check
+        self.assertEqual(result.get(), "Change loss completed")
+        d = SubscriptionRequest.objects.last()
+        self.assertEqual(d.identity, "846877e6-afaa-43de-acb1-09f61ad4de99")
+        self.assertEqual(d.messageset, 18)
+        self.assertEqual(d.next_sequence_number, 1)
+        self.assertEqual(d.lang, "hau_NG")
+        self.assertEqual(d.schedule, 1)
 
 
 class TestMetrics(AuthenticatedAPITestCase):


### PR DESCRIPTION
The text message sets don't have different days or times, so the `preferred_msg_days` and `preferred_msg_times` doesn't exist in the identity details.

The `utils.get_messageset_schedule_sequence` can handle them being None.