### PR TITLE
Convert datetimes to strings for task serialization

### DIFF
--- a/reports/tasks.py
+++ b/reports/tasks.py
@@ -16,7 +16,7 @@ from seed_services_client import (IdentityStoreApiClient,
 
 from registrations.models import Registration
 from changes.models import Change
-from reports.utils import parse_cursor_params
+from reports.utils import parse_cursor_params, midnight_validator
 
 
 class SendEmail(Task):
@@ -83,6 +83,11 @@ class GenerateReport(Task):
             email_sender=settings.DEFAULT_FROM_EMAIL,
             email_subject='Seed Control Interface Generated Report',
             **kwargs):
+
+        if type(start_date) is unicode:
+            start_date = midnight_validator(start_date)
+        if type(end_date) is unicode:
+            end_date = midnight_validator(end_date)
 
         self.identity_cache = {}
         self.messageset_cache = {}

--- a/reports/tasks.py
+++ b/reports/tasks.py
@@ -9,6 +9,7 @@ from django.core.mail import EmailMessage
 from django.utils.dateparse import parse_datetime
 from functools import partial
 from openpyxl import Workbook
+from six import string_types
 
 from seed_services_client import (IdentityStoreApiClient,
                                   StageBasedMessagingApiClient,
@@ -84,9 +85,9 @@ class GenerateReport(Task):
             email_subject='Seed Control Interface Generated Report',
             **kwargs):
 
-        if type(start_date) is unicode:
+        if isinstance(start_date, string_types):
             start_date = midnight_validator(start_date)
-        if type(end_date) is unicode:
+        if isinstance(end_date, string_types):
             end_date = midnight_validator(end_date)
 
         self.identity_cache = {}

--- a/reports/tests.py
+++ b/reports/tests.py
@@ -921,15 +921,13 @@ class ReportsViewTest(TestCase):
         self.assertEqual(request.status_code, 202)
         self.assertEqual(request.data, {"report_generation_requested": True})
 
-        mock_generation.assert_called_once_with(
-            output_file=tmp_file.name,
-            start_date=self.midnight(datetime.strptime('2016-01-01',
-                                                       '%Y-%m-%d')),
-            end_date=self.midnight(datetime.strptime('2016-02-01',
-                                                     '%Y-%m-%d')),
-            email_recipients=['foo@example.com'],
-            email_sender=settings.DEFAULT_FROM_EMAIL,
-            email_subject='The Email Subject')
+        mock_generation.assert_called_once_with(kwargs={
+            "output_file": tmp_file.name,
+            "start_date": '2016-01-01',
+            "end_date": '2016-02-01',
+            "email_recipients": ['foo@example.com'],
+            "email_sender": settings.DEFAULT_FROM_EMAIL,
+            "email_subject": 'The Email Subject'})
 
     def test_response_on_incorrect_date_format(self):
         tmp_file = self.mk_tempfile()

--- a/reports/views.py
+++ b/reports/views.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -18,12 +19,13 @@ class ReportsView(APIView):
 
         data = serializer.validated_data
 
-        generate_report.apply_async(output_file=data['output_file'],
-                                    start_date=data['start_date'],
-                                    end_date=data['end_date'],
-                                    email_recipients=data['email_to'],
-                                    email_sender=data['email_from'],
-                                    email_subject=data['email_subject'])
+        generate_report.apply_async(kwargs={
+            "output_file": data['output_file'],
+            "start_date": datetime.strftime(data['start_date'], '%Y-%m-%d'),
+            "end_date": datetime.strftime(data['end_date'], '%Y-%m-%d'),
+            "email_recipients": data['email_to'],
+            "email_sender": data['email_from'],
+            "email_subject": data['email_subject']})
         status = 202
         resp = {"report_generation_requested": True}
         return Response(resp, status=status)


### PR DESCRIPTION
Datetimes cannot be serialised for tasks so the dates are converted to strings and then converted back inside the task.