### PR TITLE
[SEED-909] Get identity using seed-services-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # hellomama-registration
-HelloMama Registration accepts registrations for the Hello Mama project.
+
+HelloMama Registration accepts registrations for [the HelloMama project](https://www.praekelt.org/hellomama/).
 
 This app uses the Django cache framework for efficient calculation of metrics,
 so if you are running multiple instances, make sure to setup a shared Django

--- a/hellomama_registration/utils.py
+++ b/hellomama_registration/utils.py
@@ -6,12 +6,19 @@ import six
 from django.conf import settings
 from registrations.models import Source
 from datetime import timedelta
+from seed_services_client import IdentityStoreApiClient
 
 session = requests.Session()
 http = requests.adapters.HTTPAdapter(max_retries=5)
 https = requests.adapters.HTTPAdapter(max_retries=5)
 session.mount('http://', http)
 session.mount('https://', https)
+
+identity_store_client = IdentityStoreApiClient(
+    api_url=settings.IDENTITY_STORE_URL,
+    auth_token=settings.IDENTITY_STORE_TOKEN,
+    retries=5,
+)
 
 
 def get_today():
@@ -78,13 +85,7 @@ def normalize_msisdn(raw, country_code):
 
 
 def get_identity(identity):
-    url = "%s/%s/%s/" % (settings.IDENTITY_STORE_URL, "identities", identity)
-    headers = {
-        'Authorization': 'Token %s' % settings.IDENTITY_STORE_TOKEN,
-        'Content-Type': 'application/json'
-    }
-    r = session.get(url, headers=headers)
-    return r.json()
+    return identity_store_client.get_identity(identity)
 
 
 def get_identity_address(identity):

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'six==1.10.0',
         'django-rest-hooks==1.3.1',
         'django-filter==0.12.0',
-        'seed-services-client>=0.23.0',
+        'seed-services-client>=0.25.0',
         'drfdocs==0.0.11',
         'pika==0.10.0',
     ],


### PR DESCRIPTION
There are many similar cases in this file and across this project. This is the smallest possible change I can make to be sure I'm doing the right thing.

Use the API client to send requests to avoid duplicating code to talk to the seed-message-sender API.