### PR TITLE
Fix for empty to_addr field

### DIFF
--- a/reports/tasks.py
+++ b/reports/tasks.py
@@ -392,7 +392,7 @@ class GenerateReport(Task):
 
             sheet.set_header(header)
 
-            for msisdn, sms_data in data.items():
+            for msisdn, sms_data in sorted(data.items()):
 
                 row = {1: msisdn}
 

--- a/reports/tasks.py
+++ b/reports/tasks.py
@@ -375,8 +375,8 @@ class GenerateReport(Task):
                         'default_addr_type', 'msisdn')
 
                     addresses = details.get('addresses', {})
-                    outbound['to_addr'] = addresses.get(
-                        default_addr_type, {}).keys()[0]
+                    outbound['to_addr'] = list(
+                        addresses.get(default_addr_type, {}).keys())[0]
 
                 count[outbound['to_addr']] += 1
                 data[outbound['to_addr']][outbound['created_at']] = \

--- a/reports/tests.py
+++ b/reports/tests.py
@@ -163,6 +163,25 @@ class GenerateReportTest(TestCase):
             status=200,
             content_type='application/json')
 
+    def add_identity_address_callback(
+            self, identity='operator_id', msisdn="+27711445511"):
+        responses.add(
+            responses.GET,
+            'http://idstore.example.com/identities/{}/addresses/msisdn?default=True'.format(identity),  # noqa
+            match_querystring=True,
+            json={
+                "count": 1,
+                "next": None,
+                "previous": None,
+                "results": [
+                    {
+                        "address": msisdn
+                    }
+                ]
+            },
+            status=200,
+            content_type='application/json')
+
     def add_blank_subscription_callback(self, next_='?foo=bar'):
         if next_:
             next_ = 'http://sbm.example.com/subscriptions/{}'.format(next_)
@@ -579,6 +598,8 @@ class GenerateReportTest(TestCase):
         self.add_identity_callback('17cf37cf-edd6-4634-88e3-f793575f7e3a')
 
         self.add_blank_outbound_callback()
+
+        self.add_identity_address_callback('receiver_id', '+2340000000000')
 
         # Create 4 outbounds with to_addr populated and 4 with to_identity
         self.add_outbound_callback(

--- a/reports/tests.py
+++ b/reports/tests.py
@@ -626,10 +626,10 @@ class GenerateReportTest(TestCase):
         # Assert 2 rows are written
         self.assertSheetRow(
             tmp_file, 'SMS delivery per MSISDN', 1,
-            ['+2340000001111', 'Yes', 'No', 'Yes', 'No'])
+            ['+2340000000000', 'Yes', 'No', 'Yes', 'No'])
         self.assertSheetRow(
             tmp_file, 'SMS delivery per MSISDN', 2,
-            ['+2340000000000', 'Yes', 'No', 'Yes', 'No'])
+            ['+2340000001111', 'Yes', 'No', 'Yes', 'No'])
 
     @responses.activate
     @mock.patch("os.remove")

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'six==1.10.0',
         'django-rest-hooks==1.3.1',
         'django-filter==0.12.0',
-        'seed-services-client>=0.25.0',
+        'seed-services-client>=0.26.0',
         'drfdocs==0.0.11',
         'pika==0.10.0',
     ],


### PR DESCRIPTION
Recently we deployed changes for POPI compliance which meant we removed the msisdn from the `to_addr` field on all outbounds in the message sender database.

The CI report sms delivery tab grouped by the `to_addr` field, so all messages were added to one single line where the msisdn was empty, the result was more columns than excel can handle and it failed.

This PR will do a identity lookup if the msisdn is not present.