### PR TITLE
Fix household only and identity patch

### DIFF
--- a/changes/serializers.py
+++ b/changes/serializers.py
@@ -81,7 +81,8 @@ class AdminChangeSerializer(serializers.Serializer):
 
 
 class AddChangeSerializer(serializers.ModelSerializer):
-    msisdn = serializers.CharField(required=True)
+    msisdn = serializers.CharField(required=False, allow_null=True,
+                                   allow_blank=True)
 
     class Meta:
         model = Change

--- a/changes/views.py
+++ b/changes/views.py
@@ -313,9 +313,12 @@ class AddChangeView(generics.CreateAPIView):
 
         ids_client = IdentityStoreApiClient(
             settings.IDENTITY_STORE_TOKEN, settings.IDENTITY_STORE_URL)
-        data['msisdn'] = utils.normalize_msisdn(data['msisdn'], '234')
-        identity = ids_client.get_identity_by_address('msisdn', data['msisdn'])
-        data['mother_id'] = identity['results'][0]['id']
+
+        if data.get('msisdn'):
+            data['msisdn'] = utils.normalize_msisdn(data['msisdn'], '234')
+            identity = ids_client.get_identity_by_address('msisdn',
+                                                          data['msisdn'])
+            data['mother_id'] = identity['results'][0]['id']
 
         if ('voice_days' in data['data']):
             data['data']['voice_days'] = utils.get_voice_days(
@@ -337,20 +340,26 @@ class AddChangeView(generics.CreateAPIView):
             data['data']['household_msisdn'] = utils.normalize_msisdn(
                 data['data']['household_msisdn'], '234')
             household = ids_client.get_identity_by_address(
-                'msisdn', data['data']['household_msisdn'])
-            data['data']['household_id'] = household['results'][0]['id']
+                'msisdn', data['data']['household_msisdn'])['results'][0]
+            data['data']['household_id'] = household['id']
+
+            if (not data.get('msisdn') and
+                    household['details'].get('linked_to')):
+                data['mother_id'] = household['details']['linked_to']
 
         if 'unsubscribe' in data['action']:
             identity_id = data['mother_id']
+            msisdn = data.get('msisdn')
             if data['action'] == 'unsubscribe_household_only':
                 identity_id = data['data']['household_id']
+                msisdn = data.get('household_msisdn')
 
             optout_info = {
                 'optout_type': 'stop',
                 'identity': identity_id,
                 'reason': data['data']['reason'],
                 'address_type': 'msisdn',
-                'address': data['msisdn'],
+                'address': msisdn,
                 'request_source': source.name,
                 'requestor_source_id': source.id
             }

--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -412,7 +412,9 @@ class PullThirdPartyRegistrations(Task):
             for identity in identities:
                 if details:
                     identity['details'].update(details)
-                    utils.patch_identity(identity['id'], identity['details'])
+                    utils.patch_identity(
+                        identity['id'],
+                        {'details': identity['details']})
                 return identity
 
             identity = {
@@ -529,7 +531,7 @@ class PullThirdPartyRegistrations(Task):
         if mother_identity:
             mother_identity['details'].update(identity_details)
             utils.patch_identity(mother_identity['id'],
-                                 mother_identity['details'])
+                                 {'details': mother_identity['details']})
 
         if line['type_of_registration'] == 'prebirth':
             reg_info['data']['last_period_date'] = \


### PR DESCRIPTION
Fix for changes household identities - there is no mother msisdn to send so we need to get it from the father/friend/family identity's `linked_to` field.

The identity patch was incorrect, also fixed that.