### PR TITLE
Gatekeeper should be linked to mother

### DIFF
--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -525,10 +525,15 @@ class PullThirdPartyRegistrations(Task):
 
             if receiver in ('father_only', 'family_only', 'friend_only'):
                 mother_identity = self.get_or_create_identity(
-                    None, receiver_identity['id'])
+                    None, receiver_identity['id'], identity_details)
                 reg_info['mother_id'] = mother_identity['id']
 
-        if mother_identity:
+                receiver_details["linked_to"] = mother_identity['id']
+                utils.patch_identity(receiver_identity['id'],
+                                     {'details': receiver_details})
+
+        if (mother_identity and
+                receiver not in ('father_only', 'family_only', 'friend_only')):
             mother_identity['details'].update(identity_details)
             utils.patch_identity(mother_identity['id'],
                                  {'details': mother_identity['details']})

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -3788,6 +3788,24 @@ class TestAddRegistrationsAPI(TestThirdPartyRegistrations):
         self.assertEqual(
             reg.updated_by, User.objects.get(username='testadminuser'))
 
+        mother_patch = responses.calls[4]
+        self._check_request(
+            mother_patch.request, 'PATCH',
+            data={
+                'details': {
+                    'default_addr_type': 'msisdn',
+                    'gravida': '2',
+                    'operator_id': operator_id,
+                    'preferred_language': 'eng_NG',
+                    'preferred_msg_days': 'tue_thu',
+                    'preferred_msg_times': '2_5',
+                    'preferred_msg_type': 'audio',
+                    'receiver_role': 'father',
+                    'linked_to': mother_id
+                }
+            }
+        )
+
     @responses.activate
     def test_add_registration_no_source(self):
         """


### PR DESCRIPTION
The `linked_to` field on the gatekeeper(father/friend/family) should be populated with the mother's identity id.