### PR TITLE
Add personnel codes API endpoint

### DIFF
--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -3960,9 +3960,7 @@ class TestPersonnelCodeView(AuthenticatedAPITestCase):
                                          content_type='application/json')
 
         self.assertEqual(response.status_code, 200)
-
-        results = json.loads(response.content)['results']
-        self.assertEqual(results, ['11111', '22222'])
+        self.assertEqual(response.data['results'], ['11111', '22222'])
 
     @responses.activate
     def test_return_personnel_codes_post(self):

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -3960,4 +3960,4 @@ class TestPersonnelCodeView(AuthenticatedAPITestCase):
                                          content_type='application/json')
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data['results'], ['11111', '22222'])
+        self.assertEqual(sorted(response.data['results']), ['11111', '22222'])

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -3924,3 +3924,64 @@ class TestAddRegistrationsAPI(TestThirdPartyRegistrations):
             response.data['error'].find("This field may not be null") != -1)
 
         self.assertEqual(Registration.objects.count(), 0)
+
+
+class TestPersonnelCodeView(AuthenticatedAPITestCase):
+
+    def mock_identity_search(self, identities=[]):
+        responses.add(
+            responses.GET,
+            'http://localhost:8001/api/v1/identities/search/?details__has_key=personnel_code',  # noqa
+            json={
+                "count": len(identities), "next": None, "previous": None,
+                "results": identities
+            },
+            status=200, content_type='application/json',
+            match_querystring=True
+        )
+
+    @responses.activate
+    def test_return_personnel_codes(self):
+        """
+        It should return ids and codes of personnel
+        """
+
+        identities = [{
+            "id": "4038a518-2940-4b15-9c5c-2b7b123b8735",
+            "details": {"personnel_code": "11111"}
+        }, {
+            "id": "4038a518-1111-1111-1111-hfud7383gfyt",
+            "details": {"personnel_code": "22222"}
+        }]
+
+        self.mock_identity_search(identities)
+
+        response = self.normalclient.get('/api/v1/personnelcode/',
+                                         content_type='application/json')
+
+        self.assertEqual(response.status_code, 200)
+
+        results = json.loads(response.content)['results']
+        self.assertEqual(results, ['11111', '22222'])
+
+    @responses.activate
+    def test_return_personnel_codes_post(self):
+        """
+        It should not allow POST method
+        """
+
+        response = self.normalclient.post('/api/v1/personnelcode/', {},
+                                          content_type='application/json')
+
+        self.assertEqual(response.status_code, 405)
+
+    @responses.activate
+    def test_return_personnel_codes_patch(self):
+        """
+        It should not allow PATCH method
+        """
+
+        response = self.normalclient.patch('/api/v1/personnelcode/', {},
+                                           content_type='application/json')
+
+        self.assertEqual(response.status_code, 405)

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -3961,25 +3961,3 @@ class TestPersonnelCodeView(AuthenticatedAPITestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['results'], ['11111', '22222'])
-
-    @responses.activate
-    def test_return_personnel_codes_post(self):
-        """
-        It should not allow POST method
-        """
-
-        response = self.normalclient.post('/api/v1/personnelcode/', {},
-                                          content_type='application/json')
-
-        self.assertEqual(response.status_code, 405)
-
-    @responses.activate
-    def test_return_personnel_codes_patch(self):
-        """
-        It should not allow PATCH method
-        """
-
-        response = self.normalclient.patch('/api/v1/personnelcode/', {},
-                                           content_type='application/json')
-
-        self.assertEqual(response.status_code, 405)

--- a/registrations/urls.py
+++ b/registrations/urls.py
@@ -23,4 +23,6 @@ urlpatterns = [
         views.ThirdPartyRegistrationView.as_view()),
     url(r'^api/v1/addregistration/$',
         views.AddRegistrationView.as_view()),
+    url(r'^api/v1/personnelcode/$',
+        views.PersonnelCodeView.as_view()),
 ]

--- a/registrations/views.py
+++ b/registrations/views.py
@@ -224,7 +224,7 @@ class PersonnelCodeView(APIView):
 
     def get(self, request, *args, **kwargs):
         identities = utils.search_identities(
-            {"details__has_key": "personnel_code"})
+            "details__has_key", "personnel_code")
 
         codes = set()
         for identity in identities:

--- a/registrations/views.py
+++ b/registrations/views.py
@@ -10,7 +10,7 @@ from rest_framework.authtoken.models import Token
 from .serializers import (UserSerializer, GroupSerializer,
                           SourceSerializer, RegistrationSerializer,
                           HookSerializer, CreateUserSerializer)
-from hellomama_registration.utils import get_available_metrics
+from hellomama_registration import utils
 # Uncomment line below if scheduled metrics are added
 # from .tasks import scheduled_metrics
 from .tasks import pull_third_party_registrations
@@ -92,7 +92,7 @@ class MetricsView(APIView):
     def get(self, request, *args, **kwargs):
         status = 200
         resp = {
-            "metrics_available": get_available_metrics()
+            "metrics_available": utils.get_available_metrics()
         }
         return Response(resp, status=status)
 
@@ -211,5 +211,25 @@ class AddRegistrationView(APIView):
             resp['registration_added'] = False
             resp['error'] = str(error)
             status = 400
+
+        return Response(resp, status=status)
+
+
+class PersonnelCodeView(APIView):
+
+    """ PersonnelCodeView Interaction
+        GET - returns a list of identities with personnel codes
+    """
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request, *args, **kwargs):
+        status = 200
+        resp = {"results": []}
+
+        identities = utils.search_identities(
+            {"details__has_key": "personnel_code"})
+
+        for identity in identities:
+            resp["results"].append(identity['details'].get('personnel_code'))
 
         return Response(resp, status=status)

--- a/registrations/views.py
+++ b/registrations/views.py
@@ -218,18 +218,16 @@ class AddRegistrationView(APIView):
 class PersonnelCodeView(APIView):
 
     """ PersonnelCodeView Interaction
-        GET - returns a list of identities with personnel codes
+        GET - returns a list of personnel codes
     """
     permission_classes = (IsAuthenticated,)
 
     def get(self, request, *args, **kwargs):
-        status = 200
-        resp = {"results": []}
-
         identities = utils.search_identities(
             {"details__has_key": "personnel_code"})
 
+        codes = set()
         for identity in identities:
-            resp["results"].append(identity['details'].get('personnel_code'))
+            codes.add(identity['details'].get('personnel_code'))
 
-        return Response(resp, status=status)
+        return Response({"results": list(codes)}, status=200)


### PR DESCRIPTION
This is for vas2nets to update their list of personnel codes to validate against. It's in this repo because it is hellomama specific and I don't want them to call the Identity-store directly because there might be personal info on the identity that we don't want to share.