### PR TITLE
Harden report export from missing addresses

### DIFF
--- a/reports/tests.py
+++ b/reports/tests.py
@@ -907,7 +907,7 @@ class GenerateReportTest(TestCase):
             },
         })
 
-        self.assertEqual(addresses, [])
+        self.assertEqual(sorted(addresses), [])
 
 
 class ReportsViewTest(TestCase):

--- a/reports/tests.py
+++ b/reports/tests.py
@@ -846,6 +846,69 @@ class GenerateReportTest(TestCase):
                 "Test reason",
             ])
 
+    def test_get_addresses_from_identity(self):
+        """
+        Getting the addresses from the identity results in the correct
+        addresses being returned.
+        """
+        addresses = generate_report.get_addresses_from_identity({
+            'details': {
+                'default_addr_type': 'foo',
+                'addresses': {
+                    'foo': {
+                        'addr1': {},
+                        'addr2': {},
+                    },
+                    'bar': {
+                        'addr3': {},
+                        'addr4': {},
+                    },
+                },
+            },
+        })
+
+        self.assertEqual(sorted(addresses), ['addr1', 'addr2'])
+
+    def test_get_addresses_from_identity_defaults_msisdn(self):
+        """
+        If no default address type is specified, it should default to getting
+        msisdn addresses.
+        """
+        addresses = generate_report.get_addresses_from_identity({
+            'details': {
+                'addresses': {
+                    'msisdn': {
+                        'addr1': {},
+                        'addr2': {},
+                    },
+                    'bar': {
+                        'addr3': {},
+                        'addr4': {},
+                    },
+                },
+            },
+        })
+
+        self.assertEqual(sorted(addresses), ['addr1', 'addr2'])
+
+    def test_get_addresses_from_identity_no_msisdns(self):
+        """
+        If the identity has no addresses of the address type, then an empty
+        list should be returned.
+        """
+        addresses = generate_report.get_addresses_from_identity({
+            'details': {
+                'addresses': {
+                    'bar': {
+                        'addr3': {},
+                        'addr4': {},
+                    },
+                },
+            },
+        })
+
+        self.assertEqual(addresses, [])
+
 
 class ReportsViewTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
During QA, we got the following stack track for report generation:

```[2017-10-20 12:48:17,231: ERROR/MainProcess] Task reports.tasks.GenerateReport[9c27533b-7be7-431c-b3d8-a36c4d70cfcb] raised unexpected: IndexError('list index out of range',) Traceback (most recent call last): File "/usr/local/lib/python2.7/site-packages/celery/app/trace.py", line 240, in trace_task R = retval = fun(*args, **kwargs) File "/usr/local/lib/python2.7/site-packages/celery/app/trace.py", line 438, in __protected_call__ return self.run(*args, **kwargs) File "/app/reports/tasks.py", line 140, in run self.handle_registrations(sheet, start_date, end_date) File "/app/reports/tasks.py", line 262, in handle_registrations 'addresses', {}).get('msisdn', {}))[0] IndexError: list index out of range```

This PR aims to solve this issue.