### PR TITLE
Fix missing gatekeeper for registration report generation

### DIFF
--- a/reports/tasks.py
+++ b/reports/tasks.py
@@ -256,7 +256,7 @@ class GenerateReport(BaseTask):
             msisdns = self.get_addresses_from_identity(receiver_identity)
 
             linked_id = receiver_details.get('linked_to')
-            gatekeeper_msisdns = None
+            gatekeeper_msisdns = []
 
             if linked_id:
                 linked_identity = self.get_identity(linked_id)


### PR DESCRIPTION
When generating the report, we use `','.join(msisdns)` to create the cell value for the list of msisdns. But when an identity doesn't have a gatekeeper, we default that value to None. This causes an error with the `join` function. This should default to `[]` so that the join function produces an empty string.