### PR TITLE
Change old personnel code lookup

### DIFF
--- a/registrations/management/commands/fix_v2n_registrations_operator.py
+++ b/registrations/management/commands/fix_v2n_registrations_operator.py
@@ -31,9 +31,10 @@ class Command(BaseCommand):
             if 'personnel_code' not in operator['details']:
 
                 try:
+                    code = operator['details']['addresses']['msisdn'].keys()[0]
+
                     identities = utils.search_identities(
-                        "details__personnel_code",
-                        operator['details']['default_address'])
+                        "details__personnel_code", code)
                     identity = next(identities)
 
                     new_operator_id = identity['id']

--- a/registrations/management/commands/fix_v2n_registrations_operator.py
+++ b/registrations/management/commands/fix_v2n_registrations_operator.py
@@ -31,7 +31,8 @@ class Command(BaseCommand):
             if 'personnel_code' not in operator['details']:
 
                 try:
-                    code = operator['details']['addresses']['msisdn'].keys()[0]
+                    code = list(
+                        operator['details']['addresses']['msisdn'].keys())[0]
 
                     identities = utils.search_identities(
                         "details__personnel_code", code)

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -4337,7 +4337,13 @@ class TestFixV2NRegistrationsCommand(AuthenticatedAPITestCase):
             url,
             json={
                 "id": "operator-id-old",
-                "details": {"default_address": "12345"},
+                "details": {
+                    "addresses": {
+                        "msisdn": {
+                            "12345": {}
+                        }
+                    }
+                },
             },
             status=200, content_type='application/json',
             match_querystring=True


### PR DESCRIPTION
I got the old personnel code from the incorrectly created identity using the `default_address` field. I made a incorrect assumption that this will always be populated.

The `msisdn` will always be populated so I'm using that instead.