### PR TITLE
Resend api for vas2nets

### DIFF
--- a/hellomama_registration/utils.py
+++ b/hellomama_registration/utils.py
@@ -197,6 +197,10 @@ def patch_subscription(subscription, data):
         subscription["id"], data)
 
 
+def resend_subscription(subscription_id):
+    return stage_based_messaging_client.resend_subscription(subscription_id)
+
+
 def deactivate_subscription(subscription):
     """ Sets a subscription deactive via a Patch request
     """

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'six==1.10.0',
         'django-rest-hooks==1.3.1',
         'django-filter==0.12.0',
-        'seed-services-client>=0.31.0',
+        'seed-services-client>=0.33.0',
         'drfdocs==0.0.11',
         'pika==0.10.0',
         'sftpclone==1.2',

--- a/vas2nets/urls.py
+++ b/vas2nets/urls.py
@@ -6,4 +6,6 @@ urlpatterns = [
         views.FetchVoiceDataView.as_view()),
     url(r'^api/v1/sync_welcome_audio/$',
         views.SyncWelcomeAudioView.as_view()),
+    url(r'^api/v1/resend_last_message/$',
+        views.ResendLastMessageView.as_view()),
 ]


### PR DESCRIPTION
Vas2nets is not able to send calls on 55500 to us with a separate long number.

We suggested a api that they can call instead. This will do the same thing as the jsbox app previously did. Find identity and all active subscriptions and requeue the last outbound.