### PR TITLE
Send welcome messages for public registrations

### DIFF
--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -238,7 +238,25 @@ class ValidateRegistration(Task):
         }
 
         # Add mother welcome message
-        if 'voice_days' in registration.data and \
+        if registration.stage == 'public':
+            if registration.data["msg_receiver"] not in [
+                    "father_only", "friend_only", "family_only"]:
+                payload = {
+                    "to_identity": registration.id,
+                    "content": settings.MOTHER_WELCOME_TEXT_NG_ENG,
+                    "metadata": {}
+                }
+                utils.post_message(payload)
+
+            if registration.data["msg_receiver"] != 'mother_only':
+                payload = {
+                    "to_identity": registration.data["receiver_id"],
+                    "content": settings.MOTHER_WELCOME_TEXT_NG_ENG,
+                    "metadata": {}
+                }
+                utils.post_message(payload)
+
+        elif 'voice_days' in registration.data and \
                 registration.data["voice_days"] != "":
             mother_sub["metadata"]["prepend_next_delivery"] = \
                 "%s/static/audio/registration/%s/welcome_mother.mp3" % (

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -1948,7 +1948,6 @@ class TestSubscriptionRequest(AuthenticatedAPITestCase):
             status=200, content_type='application/json',
             match_querystring=True
         )
-
         # mock mother SMS send
         responses.add(
             responses.POST,
@@ -2018,6 +2017,13 @@ class TestSubscriptionRequest(AuthenticatedAPITestCase):
             json={"id": 6, "day_of_week": "2"},
             status=200, content_type='application/json',
             match_querystring=True
+        )
+        # mock mother SMS send
+        responses.add(
+            responses.POST,
+            'http://localhost:8006/api/v1/outbound/',
+            json={"id": 1},
+            status=200, content_type='application/json',
         )
         # prepare registration data
         registration_data = {
@@ -2155,6 +2161,13 @@ class TestSubscriptionRequest(AuthenticatedAPITestCase):
             },
             status=200, content_type='application/json',
             match_querystring=True
+        )
+        # mock mother welcome SMS send
+        responses.add(
+            responses.POST,
+            'http://localhost:8006/api/v1/outbound/',
+            json={"id": 1},
+            status=200, content_type='application/json',
         )
         # prepare registration data
         registration_data = {


### PR DESCRIPTION
On completion of a public sign up, an SMS should be sent to the number(s) associated with the subscription to inform them that they have been registered to receive the HelloMama public message set.