### PR TITLE
Corp notification for non-full set registrations

### DIFF
--- a/hellomama_registration/utils.py
+++ b/hellomama_registration/utils.py
@@ -108,6 +108,18 @@ def get_identity_address(identity):
     return identity_store_client.get_identity_address(identity)
 
 
+def get_address_from_identity(identity):
+    last_address = None
+    for address, detail in identity['details'].get(
+            'addresses', {}).get('msisdn', {}).items():
+        if detail.get('optedout', False) is True:
+            pass
+        if detail.get('default', False) is True:
+            return address
+        last_address = address
+    return last_address
+
+
 def search_identities(search_key, search_value):
     """
     Returns the identities matching the given parameters
@@ -178,6 +190,11 @@ def get_messageset(messageset_id):
     return stage_based_messaging_client.get_messageset(messageset_id)
 
 
+def search_messagesets(params):
+    r = stage_based_messaging_client.get_messagesets(params=params)
+    return r["results"]
+
+
 def get_schedule(schedule_id):
     return stage_based_messaging_client.get_schedule(schedule_id)
 
@@ -186,6 +203,12 @@ def get_subscriptions(identity):
     """ Gets the active subscriptions for an identity
     """
     params = {'identity': identity, 'active': True}
+    return search_subscriptions(params)
+
+
+def search_subscriptions(params):
+    """ Gets the subscriptions based on the params
+    """
     r = stage_based_messaging_client.get_subscriptions(params=params)
     return r["results"]
 

--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -663,13 +663,9 @@ class SendPublicRegistrationNotifications(Task):
 
     def run(self):
 
-        messagesets = utils.search_messagesets(
-            {'short_name__contains': 'public'})
-        messageset_ids = [str(messageset['id']) for messageset in messagesets]
-
         subscriptions = utils.search_subscriptions(
             {'completed': True, 'metadata_not_has_key': 'public_notification',
-             'messageset__in': ','.join(messageset_ids)})
+             'messageset_contains': 'public'})
 
         corp_details = defaultdict(list)
 

--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -663,8 +663,9 @@ class SendPublicRegistrationNotifications(Task):
 
     def send_notifications(self, details):
 
-        def chunker(seq, size):
-            return (seq[pos:pos + size] for pos in xrange(0, len(seq), size))
+        def chunker(l, n):
+            for i in range(0, len(l), n):
+                yield l[i:i + n]
 
         for corp_id, msisdns in details.items():
             for group in chunker(msisdns, 15):

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -4837,27 +4837,6 @@ class TestSendPublicRegistrationNotifications(AuthenticatedAPITestCase):
             match_querystring=True
         )
 
-    def mock_messageset_search(self):
-        responses.add(
-            responses.GET,
-            'http://localhost:8005/api/v1/messageset/?short_name__contains'
-            '=public',
-            json={
-                "next": None,
-                "previous": None,
-                "results": [{
-                    "id": 1,
-                    "short_name": 'public.mother.audio.0_4.tue.6_8',
-                    "default_schedule": 1
-                }, {
-                    "id": 2,
-                    "short_name": 'public.mother.text.0_4',
-                    "default_schedule": 2
-                }]
-            }, status=200, content_type='application/json',
-            match_querystring=True
-        )
-
     def mock_identity_get(self, identity_id, operator_id, msisdn="+234123"):
         responses.add(
             responses.GET,
@@ -4896,16 +4875,14 @@ class TestSendPublicRegistrationNotifications(AuthenticatedAPITestCase):
         # mock public subscription lookup
         self.mock_subscription_search(
             'completed=True&metadata_not_has_key=public_notification&'
-            'messageset__in=1%2C2')
-        # mock public messageset lookup
-        self.mock_messageset_search()
+            'messageset_contains=public')
 
         # Execute
         result = send_public_registration_notifications.apply_async()
         # Check
         self.assertEqual(result.get(), "0 CORP notification(s) sent")
 
-        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(len(responses.calls), 1)
 
     @responses.activate
     def test_send_notifications_no_active(self):
@@ -4919,13 +4896,11 @@ class TestSendPublicRegistrationNotifications(AuthenticatedAPITestCase):
         operator_id = "nurse000-6a07-4377-a4f6-c0485ccba234"
         subscription_id1 = "subscription1-4bf1-8779-c47b428e89d0"
         subscription_id2 = "subscription2-4bf1-8779-c47b428e89d0"
-        # mock public messageset lookup
-        self.mock_messageset_search()
 
         # mock public subscription lookup
         self.mock_subscription_search(
             'completed=True&metadata_not_has_key=public_notification&'
-            'messageset__in=1%2C2', [{
+            'messageset_contains=public', [{
                 "id": subscription_id1,
                 "active": False,
                 "completed": True,
@@ -4960,7 +4935,7 @@ class TestSendPublicRegistrationNotifications(AuthenticatedAPITestCase):
         # Check
         self.assertEqual(result.get(), "1 CORP notification(s) sent")
 
-        self.assertEqual(len(responses.calls), 9)
+        self.assertEqual(len(responses.calls), 8)
 
         # check the subscription patch
         call = responses.calls[-2]
@@ -4987,13 +4962,11 @@ class TestSendPublicRegistrationNotifications(AuthenticatedAPITestCase):
         # Setup
         mother_id = "mother00-9d89-4aa6-99ff-13c225365b5d"
         subscription_id = "subscription1-4bf1-8779-c47b428e89d0"
-        # mock public messageset lookup
-        self.mock_messageset_search()
 
         # mock public subscription lookup
         self.mock_subscription_search(
             'completed=True&metadata_not_has_key=public_notification&'
-            'messageset__in=1%2C2', [{
+            'messageset_contains=public', [{
                 "id": subscription_id,
                 "active": False,
                 "completed": True,
@@ -5020,7 +4993,7 @@ class TestSendPublicRegistrationNotifications(AuthenticatedAPITestCase):
         # Check
         self.assertEqual(result.get(), "0 CORP notification(s) sent")
 
-        self.assertEqual(len(responses.calls), 4)
+        self.assertEqual(len(responses.calls), 3)
 
         # check the subscription patch
         call = responses.calls[-1]

--- a/registrations/urls.py
+++ b/registrations/urls.py
@@ -25,4 +25,6 @@ urlpatterns = [
         views.AddRegistrationView.as_view()),
     url(r'^api/v1/personnelcode/$',
         views.PersonnelCodeView.as_view()),
+    url(r'^api/v1/send_public_notifications/$',
+        views.SendPublicRegistrationNotificationView.as_view()),
 ]

--- a/registrations/views.py
+++ b/registrations/views.py
@@ -14,7 +14,8 @@ from .serializers import (UserSerializer, GroupSerializer,
 from hellomama_registration import utils
 # Uncomment line below if scheduled metrics are added
 # from .tasks import scheduled_metrics
-from .tasks import pull_third_party_registrations
+from .tasks import (
+    pull_third_party_registrations, send_public_registration_notifications)
 
 
 class CreatedAtCursorPagination(CursorPagination):
@@ -256,3 +257,18 @@ class PersonnelCodeView(APIView):
             codes.add(identity['details'].get('personnel_code'))
 
         return Response({"results": list(codes)}, status=200)
+
+
+class SendPublicRegistrationNotificationView(APIView):
+
+    """ Triggers a notification send to operators about subscribers not on the
+        full set
+    """
+    permission_classes = (IsAuthenticated,)
+
+    def post(self, request, *args, **kwargs):
+
+        status = 202
+        accepted = {"accepted": True}
+        send_public_registration_notifications.delay()
+        return Response(accepted, status=status)


### PR DESCRIPTION
I messed up the branch, it should be MOMNG-889.

This is to send notification to the corps on the subscribers they registered on the public messageset, If they complete the messageset and is not moved to the full one then a notification is sent.

The Corp gets a list of msisdns, it is triggered by a url so can be weekly or daily.