### PR TITLE
Add key for reporting

### DIFF
--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -216,8 +216,14 @@ class ValidateRegistration(Task):
                 {"identity": registration.mother_id, "completed": False,
                  "active": True, "messageset_contains": "public.mother"})
 
+            def deactivate_subscription(sub):
+                metadata = sub['metadata']
+                metadata['converted_full'] = 'true'
+                utils.patch_subscription(
+                    sub, {"metadata": metadata, "active": False})
+
             for subscription in subscriptions:
-                utils.deactivate_subscription(subscription)
+                deactivate_subscription(subscription)
 
             registrations = Registration.objects.filter(
                 mother_id=registration.mother_id, stage='public',
@@ -233,7 +239,7 @@ class ValidateRegistration(Task):
                          "active": True})
 
                     for subscription in subscriptions:
-                        utils.deactivate_subscription(subscription)
+                        deactivate_subscription(subscription)
 
     def create_subscriptionrequests(self, registration):
         """ Create SubscriptionRequest(s) based on the

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -5149,7 +5149,8 @@ class TestStopPublicRegistrations(AuthenticatedAPITestCase):
                 "completed": False,
                 "process_status": 0,
                 "messageset": 1,
-                "identity": mother_id
+                "identity": mother_id,
+                "metadata": {"existing": "key"}
             }])
         self.mock_patch_subscription(subscription_id)
 
@@ -5162,7 +5163,13 @@ class TestStopPublicRegistrations(AuthenticatedAPITestCase):
             call.request.url,
             'http://localhost:8005/api/v1/subscriptions/{}/'.format(
                 subscription_id))
-        self.assertEqual(json.loads(call.request.body), {"active": False})
+        self.assertEqual(json.loads(call.request.body), {
+            "active": False,
+            "metadata": {
+                "converted_full": "true",
+                "existing": "key"
+            }
+        })
 
     @responses.activate
     def test_stop_public_subscription_household(self):
@@ -5193,7 +5200,8 @@ class TestStopPublicRegistrations(AuthenticatedAPITestCase):
                 "completed": False,
                 "process_status": 0,
                 "messageset": 1,
-                "identity": household_id
+                "identity": household_id,
+                "metadata": {"existing": "key"}
             }])
         self.mock_patch_subscription(subscription_id)
 
@@ -5206,4 +5214,10 @@ class TestStopPublicRegistrations(AuthenticatedAPITestCase):
             call.request.url,
             'http://localhost:8005/api/v1/subscriptions/{}/'.format(
                 subscription_id))
-        self.assertEqual(json.loads(call.request.body), {"active": False})
+        self.assertEqual(json.loads(call.request.body), {
+            "active": False,
+            "metadata": {
+                "converted_full": "true",
+                "existing": "key"
+            }
+        })


### PR DESCRIPTION
We need to know if a public subscription was converted to the full set for the following reports:
% conversion from Public to Full Message set total / per month 
% conversation from Public to Full Message set per weekly reminder (1/2/3/4).

I am assuming that if a public subscription is complete and then a full subscription is created that it is not a conversion. <- This was confirmed.